### PR TITLE
Fix missing icon in XFCE, LXQt

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -51,6 +51,9 @@ class Window(Handy.ApplicationWindow):
   def __init__(self, app):
     super().__init__(title='Wike', application=app)
 
+    # Set default window icon name for XFCE, LXQt, MATE
+    self.set_default_icon_name('com.github.hugolabe.Wike')
+
     self.set_default_size(settings.get_int('window-width'), settings.get_int('window-height'))
     if settings.get_boolean('window-max'): self.maximize()
 


### PR DESCRIPTION
The icon did not appear in panels of XFCE, LXQt, and possibly MATE.

Similar issues have been reported in https://github.com/rafaelmardojai/blanket/issues/54 and https://github.com/rafaelmardojai/blanket/issues/84 .

The fix is this https://github.com/rafaelmardojai/blanket/commit/b3d0f92f97286cd5055b6e7abba29a4adad0f568

I have verified that it works in XFCE.

Before
![Screenshot_2021-05-07-15-23-52-031_android androidVNC](https://user-images.githubusercontent.com/3063132/117435070-0e2a6700-af4b-11eb-85eb-761e069f5e02.jpg)

After
![Screenshot_2021-05-07-15-38-39-457_com realvnc viewer android](https://user-images.githubusercontent.com/3063132/117434749-b12eb100-af4a-11eb-85c9-7a22a59e29fd.jpg)
(the different icon is due to Papirus Icon theme)