### PR TITLE
view: Allow context menu

### DIFF
--- a/src/view.py
+++ b/src/view.py
@@ -323,12 +323,6 @@ class WikiView(WebKit2.WebView):
         if uri_netloc.startswith('upload.'): decision.ignore()
     return True
 
-  # Deactivate webview context menu
-
-  def do_context_menu(self, menu, event, hit_test_result):
-    return True
-
-
 # Create wikiview global object
 
 wikiview = WikiView()


### PR DESCRIPTION
I don't think there's really any incentive to disable the context menu,
and it's nice to keep it even if it's just for the basic Previous/next
history and Reload items.

-----------

Untested, but it should achieve the desired behaviour.