### PR TITLE
Draft: Port to GTK4+Libadwaita

### DIFF
--- a/build-aux/flatpak/com.github.hugolabe.Wike.json
+++ b/build-aux/flatpak/com.github.hugolabe.Wike.json
@@ -1,7 +1,7 @@
 {
   "app-id" : "com.github.hugolabe.Wike",
   "runtime" : "org.gnome.Platform",
-  "runtime-version" : "40",
+  "runtime-version" : "master",
   "sdk" : "org.gnome.Sdk",
   "command" : "wike",
   "finish-args" : [

--- a/build-aux/flatpak/com.github.hugolabe.Wike.json
+++ b/build-aux/flatpak/com.github.hugolabe.Wike.json
@@ -1,31 +1,34 @@
 {
-  "app-id" : "com.github.hugolabe.Wike",
-  "runtime" : "org.gnome.Platform",
-  "runtime-version" : "master",
-  "sdk" : "org.gnome.Sdk",
-  "command" : "wike",
-  "finish-args" : [
-    "--share=network",
-    "--share=ipc",
-    "--socket=fallback-x11",
-    "--socket=wayland",
-    "--socket=pulseaudio",
-    "--device=dri",
-    "--own-name=com.github.hugolabe.Wike.SearchProvider"
-  ],
-  "modules" : [
-    "python3-dbus-python.json",
-    "python3-requests.json",
-    {
-      "name" : "wike",
-      "buildsystem" : "meson",
-      "builddir" : true,
-      "sources" : [
+    "app-id" : "com.github.hugolabe.Wike",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "master",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "wike",
+    "finish-args" : [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        "--device=dri",
+        "--own-name=com.github.hugolabe.Wike.SearchProvider"
+    ],
+    "modules" : [
+        "python3-dbus-python.json",
+        "python3-requests.json",
         {
-          "type" : "dir",
-          "path" : "../../."
+            "name" : "wike",
+            "buildsystem" : "meson",
+            "builddir" : true,
+            "sources" : [
+                {
+                    "type" : "dir",
+                    "path" : "../../."
+                }
+            ]
         }
-      ]
+    ],
+    "build-options" : {
+        "env" : {        }
     }
-  ]
 }

--- a/data/ui/about.ui
+++ b/data/ui/about.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkAboutDialog" id="about_dialog">
     <property name="program_name">Wike</property>
     <property name="version">1.6.1</property>

--- a/data/ui/bookmarks-row.ui
+++ b/data/ui/bookmarks-row.ui
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk" version="4.0"/>
   <template class="BookmarkBoxRow" parent="GtkListBoxRow">
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="margin_left">6</property>
-        <property name="margin_right">3</property>
+        
+        
+        <property name="margin_start">6</property>
+        <property name="margin_end">3</property>
         <property name="margin_top">3</property>
         <property name="margin_bottom">3</property>
         <property name="spacing">12</property>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            
+            
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="article_title">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                
+                
                 <property name="halign">start</property>
                 <property name="ellipsize">end</property>
               </object>
@@ -31,8 +31,8 @@
             </child>
             <child>
               <object class="GtkLabel" id="article_lang">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                
+                
                 <property name="halign">start</property>
                 <property name="use_markup">True</property>
                 <property name="ellipsize">end</property>
@@ -54,13 +54,13 @@
           <object class="GtkButton" id="remove_button">
             <property name="width_request">36</property>
             <property name="height_request">36</property>
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            
+            
             <property name="relief">none</property>
             <child>
               <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                
+                
                 <property name="icon_name">window-close-symbolic</property>
               </object>
             </child>

--- a/data/ui/bookmarks.ui
+++ b/data/ui/bookmarks.ui
@@ -1,38 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk" version="4.0"/>
   <template class="BookmarksPopover" parent="GtkPopover">
-    <property name="can_focus">False</property>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="border_width">10</property>
         <property name="orientation">vertical</property>
         <property name="spacing">8</property>
         <child>
           <object class="GtkScrolledWindow">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="shadow_type">in</property>
             <property name="min_content_width">260</property>
             <property name="max_content_height">400</property>
             <property name="hscrollbar-policy">never</property>
             <property name="propagate_natural_height">True</property>
             <child>
               <object class="GtkViewport">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <child>
                   <object class="GtkListBox" id="bookmarks_list">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
                     <child type="placeholder">
                       <object class="GtkLabel" id="placeholder_label">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xpad">10</property>
-                        <property name="ypad">30</property>
                         <property name="justify">center</property>
                       </object>
                     </child>
@@ -41,48 +26,22 @@
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="spacing">8</property>
             <property name="homogeneous">True</property>
             <child>
               <object class="GtkButton" id="add_button">
                 <property name="label" translatable="yes">Add Bookmark</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton" id="clear_button">
                 <property name="label" translatable="yes">Clear List</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/data/ui/header.ui
+++ b/data/ui/header.ui
@@ -3,14 +3,6 @@
   <requires lib="gtk" version="4.0"/>
   <requires lib="libadwaita" version="1.0"/>
   <template class="HeaderBar" parent="GtkHeaderBar">
-		<property name="title-widget">
-			<object class="GtkLabel" id="window_title">
-				<property name="label" translatable="no">Wike</property>
-				<style>
-        	<class name="title"/>
-      	</style>
-			</object>
-		</property>
     <child>
       <object class="GtkBox">
         <child>

--- a/data/ui/header.ui
+++ b/data/ui/header.ui
@@ -6,6 +6,9 @@
 		<property name="title-widget">
 			<object class="GtkLabel" id="window_title">
 				<property name="label" translatable="no">Wike</property>
+				<style>
+        	<class name="title"/>
+      	</style>
 			</object>
 		</property>
     <child>
@@ -13,93 +16,55 @@
         <child>
           <object class="GtkButton" id="prev_button">
             <property name="action_name">win.prev_page</property>
-            <child>
-              <object class="GtkImage">
-                <property name="icon_name">go-previous-symbolic</property>
-              </object>
-            </child>
+            <property name="icon_name">go-previous-symbolic</property>
           </object>
         </child>
         <child>
           <object class="GtkButton" id="next_button">
             <property name="action_name">win.next_page</property>
-            <child>
-              <object class="GtkImage">
-                <property name="icon_name">go-next-symbolic</property>
-              </object>
-            </child>
+            <property name="icon_name">go-next-symbolic</property>
           </object>
         </child>
-        <style>
-          <class name="linked"/>
-        </style>
-      </object>
-    </child>
-    <child>
-      <object class="GtkButton" id="tab_button">
-        <property name="tooltip-text" translatable="yes">New tab</property>
-        <property name="action_name">win.new_tab</property>
         <child>
-          <object class="GtkImage">
+          <object class="GtkButton" id="tab_button">
+            <property name="tooltip-text" translatable="yes">New tab</property>
+            <property name="action_name">win.new_tab</property>
             <property name="icon_name">tab-new-symbolic</property>
           </object>
         </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkToggleButton" id="search_button">
-        <property name="tooltip-text" translatable="yes">Search articles</property>
         <child>
-          <object class="GtkImage">
+          <object class="GtkToggleButton" id="search_button">
+            <property name="tooltip-text" translatable="yes">Search articles</property>
             <property name="icon_name">edit-find-symbolic</property>
           </object>
         </child>
       </object>
     </child>
-    <child>
-      <object class="GtkMenuButton" id="menu_button">
-        <child>
-          <object class="GtkImage">
-            <property name="icon_name">open-menu-symbolic</property>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkMenuButton" id="bookmarks_button">
-        <property name="tooltip-text" translatable="yes">Bookmarks</property>
-        <child>
-          <object class="GtkImage">
-            <property name="icon_name">user-bookmarks-symbolic</property>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
+    <child type="end">
       <object class="GtkBox">
         <child>
           <object class="GtkMenuButton" id="toc_button">
             <property name="tooltip-text" translatable="yes">Table of contents</property>
-            <child>
-              <object class="GtkImage">
-                <property name="icon_name">view-list-symbolic</property>
-              </object>
-            </child>
+            <property name="icon_name">view-list-symbolic</property>
           </object>
         </child>
         <child>
           <object class="GtkMenuButton" id="langlinks_button">
             <property name="tooltip-text" translatable="yes">View article in other languages</property>
-            <child>
-              <object class="GtkImage">
-                <property name="icon_name">wike-language-symbolic</property>
-              </object>
-            </child>
+            <property name="icon_name">wike-language-symbolic</property>
           </object>
         </child>
-        <style>
-          <class name="linked"/>
-        </style>
+        <child>
+          <object class="GtkMenuButton" id="bookmarks_button">
+            <property name="tooltip-text" translatable="yes">Bookmarks</property>
+            <property name="icon_name">user-bookmarks-symbolic</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkMenuButton" id="menu_button">
+            <property name="icon_name">open-menu-symbolic</property>
+          </object>
+        </child>
       </object>
     </child>
   </template>

--- a/data/ui/header.ui
+++ b/data/ui/header.ui
@@ -1,53 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
-  <requires lib="libhandy" version="1.0"/>
-  <template class="HeaderBar" parent="HdyHeaderBar">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="title" translatable="no">Wike</property>
-    <property name="show_close_button">True</property>
+  <requires lib="gtk" version="4.0"/>
+  <requires lib="libadwaita" version="1.0"/>
+  <template class="HeaderBar" parent="GtkHeaderBar">
+		<property name="title-widget">
+			<object class="GtkLabel" id="window_title">
+				<property name="label" translatable="no">Wike</property>
+			</object>
+		</property>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
         <child>
           <object class="GtkButton" id="prev_button">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="action_name">win.prev_page</property>
             <child>
               <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <property name="icon_name">go-previous-symbolic</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkButton" id="next_button">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="action_name">win.next_page</property>
             <child>
               <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <property name="icon_name">go-next-symbolic</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <style>
           <class name="linked"/>
@@ -56,124 +37,70 @@
     </child>
     <child>
       <object class="GtkButton" id="tab_button">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
         <property name="tooltip-text" translatable="yes">New tab</property>
         <property name="action_name">win.new_tab</property>
         <child>
           <object class="GtkImage">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="icon_name">tab-new-symbolic</property>
           </object>
         </child>
       </object>
-      <packing>
-        <property name="position">1</property>
-      </packing>
     </child>
     <child>
       <object class="GtkToggleButton" id="search_button">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
         <property name="tooltip-text" translatable="yes">Search articles</property>
         <child>
           <object class="GtkImage">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="icon_name">edit-find-symbolic</property>
           </object>
         </child>
       </object>
-      <packing>
-        <property name="position">2</property>
-      </packing>
     </child>
     <child>
       <object class="GtkMenuButton" id="menu_button">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
         <child>
           <object class="GtkImage">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="icon_name">open-menu-symbolic</property>
           </object>
         </child>
       </object>
-      <packing>
-        <property name="pack_type">end</property>
-        <property name="position">0</property>
-      </packing>
     </child>
     <child>
       <object class="GtkMenuButton" id="bookmarks_button">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
         <property name="tooltip-text" translatable="yes">Bookmarks</property>
         <child>
           <object class="GtkImage">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="icon_name">user-bookmarks-symbolic</property>
           </object>
         </child>
       </object>
-      <packing>
-        <property name="pack_type">end</property>
-        <property name="position">1</property>
-      </packing>
     </child>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
         <child>
           <object class="GtkMenuButton" id="toc_button">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="tooltip-text" translatable="yes">Table of contents</property>
             <child>
               <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <property name="icon_name">view-list-symbolic</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkMenuButton" id="langlinks_button">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="tooltip-text" translatable="yes">View article in other languages</property>
             <child>
               <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <property name="icon_name">wike-language-symbolic</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <style>
           <class name="linked"/>
         </style>
       </object>
-      <packing>
-        <property name="pack_type">end</property>
-        <property name="position">2</property>
-      </packing>
     </child>
   </template>
 </interface>

--- a/data/ui/langlinks-row.ui
+++ b/data/ui/langlinks-row.ui
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk" version="4.0"/>
   <template class="LanglinkBoxRow" parent="GtkListBoxRow">
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="margin_left">6</property>
-        <property name="margin_right">6</property>
+        
+        
+        <property name="margin_start">6</property>
+        <property name="margin_end">6</property>
         <property name="margin_top">3</property>
         <property name="margin_bottom">3</property>
         <property name="spacing">12</property>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            
+            
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="langlink_lang">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                
+                
                 <property name="halign">start</property>
                 <property name="ellipsize">end</property>
               </object>
@@ -31,8 +31,8 @@
             </child>
             <child>
               <object class="GtkLabel" id="langlink_title">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                
+                
                 <property name="halign">start</property>
                 <property name="use_markup">True</property>
                 <property name="ellipsize">end</property>
@@ -52,8 +52,8 @@
         </child>
         <child>
           <object class="GtkLabel" id="langlink_id">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            
+            
             <property name="valign">start</property>
           </object>
           <packing>

--- a/data/ui/langlinks.ui
+++ b/data/ui/langlinks.ui
@@ -1,52 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk" version="4.0"/>
   <template class="LanglinksPopover" parent="GtkPopover">
-    <property name="can_focus">False</property>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="border_width">10</property>
         <property name="orientation">vertical</property>
         <property name="spacing">8</property>
         <child>
-          <object class="GtkSearchEntry" id="filter_entry">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
+          <object class="GtkSearchEntry" id="filter_entry"/>
         </child>
         <child>
           <object class="GtkScrolledWindow">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="shadow_type">in</property>
             <property name="min_content_width">260</property>
             <property name="max_content_height">300</property>
             <property name="propagate_natural_height">True</property>
             <child>
               <object class="GtkViewport">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkListBox" id="langlinks_list">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                  </object>
+                  <object class="GtkListBox" id="langlinks_list"/>
                 </child>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/data/ui/menu.css
+++ b/data/ui/menu.css
@@ -1,7 +1,6 @@
 .color-button {
   padding: 12px;
   border-radius: 999px;
-  -gtk-outline-radius: 999px;
   outline-offset: 1px;
   border: none;
   -gtk-icon-shadow: none;

--- a/data/ui/menu.ui
+++ b/data/ui/menu.ui
@@ -6,6 +6,10 @@
     <child>
       <object class="GtkBox">
         <property name="orientation">vertical</property>
+				<property name="margin-start">6</property>
+				<property name="margin-end">6</property>
+				<property name="margin-top">6</property>
+				<property name="margin-bottom">6</property>
         <child>
           <object class="GtkBox">
             <property name="halign">center</property>
@@ -135,6 +139,9 @@
         </child>
       </object>
     </child>
+		<style>
+			<class name="menu"/>
+		</style>
   </template>
 </interface>
 

--- a/data/ui/menu.ui
+++ b/data/ui/menu.ui
@@ -1,30 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk" version="4.0"/>
   <template class="MenuPopover" parent="GtkPopover">
-    <property name="can_focus">False</property>
     <property name="width-request">280</property>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="border_width">10</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
             <property name="halign">center</property>
             <property name="margin-bottom">6</property>
             <property name="spacing">24</property>
             <child>
-              <object class="GtkRadioButton" id="light_button">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
+              <object class="GtkToggleButton" id="light_button">
                 <property name="halign">center</property>
-                <property name="draw-indicator">False</property>
                 <child>
                   <object class="GtkImage">
-                    <property name="visible">True</property>
                     <property name="icon-name">emblem-ok-symbolic</property>
                   </object>
                 </child>
@@ -33,20 +24,13 @@
                   <class name="color-light"/>
                 </style>
               </object>
-              <packing>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
-              <object class="GtkRadioButton" id="sepia_button">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
+              <object class="GtkToggleButton" id="sepia_button">
                 <property name="halign">center</property>
-                <property name="draw-indicator">False</property>
                 <property name="group">light_button</property>
                 <child>
                   <object class="GtkImage">
-                    <property name="visible">True</property>
                     <property name="icon-name">emblem-ok-symbolic</property>
                   </object>
                 </child>
@@ -55,20 +39,14 @@
                   <class name="color-sepia"/>
                 </style>
               </object>
-              <packing>
-                <property name="position">1</property>
-              </packing>
             </child>
             <child>
-              <object class="GtkRadioButton" id="dark_button">
-                <property name="visible">True</property>
+              <object class="GtkToggleButton" id="dark_button">
                 <property name="can-focus">True</property>
                 <property name="halign">center</property>
-                <property name="draw-indicator">False</property>
                 <property name="group">light_button</property>
                 <child>
                   <object class="GtkImage">
-                    <property name="visible">True</property>
                     <property name="icon-name">emblem-ok-symbolic</property>
                   </object>
                 </child>
@@ -77,161 +55,83 @@
                   <class name="color-dark"/>
                 </style>
               </object>
-              <packing>
-                <property name="position">2</property>
-              </packing>
             </child>
           </object>
         </child>
         <child>
           <object class="GtkSeparator">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkModelButton">
-            <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="text" translatable="yes">Wikipedia Main Page</property>
             <property name="action_name">win.main_page</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
         </child>
         <child>
           <object class="GtkModelButton">
-            <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="text" translatable="yes">Random Article</property>
             <property name="action_name">win.random_article</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
         </child>
         <child>
           <object class="GtkModelButton">
-            <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="text" translatable="yes">Recent Articles</property>
             <property name="action_name">win.show_historic</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">4</property>
-          </packing>
         </child>
         <child>
           <object class="GtkSeparator">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">5</property>
-          </packing>
         </child>
         <child>
           <object class="GtkModelButton">
-            <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="text" translatable="yes">Search Text in Page</property>
             <property name="action_name">win.search_text</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">6</property>
-          </packing>
         </child>
         <child>
           <object class="GtkModelButton">
-            <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="text" translatable="yes">Open Wikipedia Page in Browser</property>
             <property name="action_name">win.open_browser</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">7</property>
-          </packing>
         </child>
         <child>
           <object class="GtkModelButton">
-            <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="text" translatable="yes">Copy Wikipedia URL to Clipboard</property>
             <property name="action_name">win.copy_url</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">8</property>
-          </packing>
         </child>
         <child>
           <object class="GtkSeparator">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">10</property>
-          </packing>
         </child>
         <child>
           <object class="GtkModelButton">
-            <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="text" translatable="yes">Preferences</property>
             <property name="action_name">app.prefs</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">11</property>
-          </packing>
         </child>
         <child>
           <object class="GtkModelButton">
-            <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="text" translatable="yes">Keyboard Shortcuts</property>
             <property name="action_name">app.shortcuts</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">12</property>
-          </packing>
         </child>
         <child>
           <object class="GtkModelButton">
-            <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="text" translatable="yes">About Wike</property>
             <property name="action_name">app.about</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">13</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/data/ui/menu.ui
+++ b/data/ui/menu.ui
@@ -13,6 +13,8 @@
         <child>
           <object class="GtkBox">
             <property name="halign">center</property>
+						<property name="valign">center</property>
+						<property name="margin-top">6</property>
             <property name="margin-bottom">6</property>
             <property name="spacing">24</property>
             <child>

--- a/data/ui/page.ui
+++ b/data/ui/page.ui
@@ -1,74 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk" version="4.0"/>
   <template class="PageBox" parent="GtkBox">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkSearchBar" id="search_bar">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
         <property name="show_close_button">True</property>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="spacing">12</property>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <property name="margin-start">50</property>
                 <child>
                   <object class="GtkSearchEntry" id="textsearch_entry">
-                    <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="max_width_chars">40</property>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="textsearch_prev_button">
-                    <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="sensitive">False</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
                         <property name="icon_name">go-up-symbolic</property>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="textsearch_next_button">
-                    <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="sensitive">False</property>
                     <child>
                       <object class="GtkImage">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
                         <property name="icon_name">go-down-symbolic</property>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
                 </child>
                 <style>
                   <class name="linked"/>
@@ -77,24 +47,14 @@
             </child>
             <child>
               <object class="GtkLabel" id="textsearch_matches_label">
-                <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="width-request">50</property>
                 <property name="xalign">0</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-              </packing>
             </child>
           </object>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
     </child>
   </template>
 </interface>

--- a/data/ui/prefs-row.ui
+++ b/data/ui/prefs-row.ui
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk" version="4.0"/>
   <template class="LanguageBoxRow" parent="GtkListBoxRow">
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        
+        
         <child>
           <object class="GtkLabel" id="lang_name_label">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            
+            
             <property name="halign">start</property>
             <property name="valign">center</property>
-            <property name="margin_left">12</property>
-            <property name="margin_right">6</property>
+            <property name="margin_start">12</property>
+            <property name="margin_end">6</property>
             <property name="margin_top">4</property>
             <property name="margin_bottom">4</property>
             <property name="hexpand">True</property>
@@ -26,12 +26,12 @@
         </child>
         <child>
           <object class="GtkLabel" id="lang_id_label">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            
+            
             <property name="halign">end</property>
             <property name="valign">center</property>
-            <property name="margin_left">6</property>
-            <property name="margin_right">6</property>
+            <property name="margin_start">6</property>
+            <property name="margin_end">6</property>
             <property name="margin_top">4</property>
             <property name="margin_bottom">4</property>
           </object>
@@ -43,12 +43,12 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="lang_check">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            
+            
             <property name="halign">end</property>
             <property name="valign">center</property>
-            <property name="margin_left">12</property>
-            <property name="margin_right">18</property>
+            <property name="margin_start">12</property>
+            <property name="margin_end">18</property>
             <property name="margin_top">4</property>
             <property name="margin_bottom">4</property>
             <property name="draw_indicator">True</property>

--- a/data/ui/prefs.ui
+++ b/data/ui/prefs.ui
@@ -1,46 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
-  <requires lib="libhandy" version="1.0"/>
-  <template class="PrefsWindow" parent="HdyPreferencesWindow">
+  <requires lib="gtk" version="4.0"/>
+  <requires lib="libadwaita" version="1.0"/>
+  <template class="PrefsWindow" parent="AdwPreferencesWindow">
     <property name="default_height">425</property>
     <property name="default_width">540</property>
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>
     <property name="search-enabled">False</property>
     <child>
-      <object class="HdyPreferencesPage">
-        <property name="visible">True</property>
+      <object class="AdwPreferencesPage">
         <property name="title" translatable="yes">General</property>
         <property name="icon_name">applications-system-symbolic</property>
         <child>
-          <object class="HdyPreferencesGroup">
-            <property name="visible">True</property>
+          <object class="AdwPreferencesGroup">
             <property name="can-focus">False</property>
             <property name="title" translatable="yes">Behavior</property>
             <child>
-              <object class="HdyComboRow" id="on_start_combo">
+              <object class="AdwComboRow" id="on_start_combo">
                 <property name="title" translatable="yes">Home page</property>
                 <property name="subtitle" translatable="yes">The page that will be displayed when Wike starts</property>
-                <property name="visible">True</property>
               </object>
             </child>
           </object>
         </child>
         <child>
-          <object class="HdyPreferencesGroup">
-            <property name="visible">True</property>
+          <object class="AdwPreferencesGroup">
             <property name="can-focus">False</property>
             <property name="title" translatable="yes">Article View</property>
             <child>
-              <object class="HdyActionRow">
+              <object class="AdwActionRow">
                 <property name="title" translatable="yes">Font size</property>
                 <property name="subtitle" translatable="yes">Font size for article view (default is 16)</property>
-                <property name="visible">True</property>
                 <property name="activatable">False</property>
                 <child>
                   <object class="GtkSpinButton" id="font_size_spin">
-                    <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="valign">center</property>
                     <property name="numeric">True</property>
@@ -51,13 +45,11 @@
               </object>
             </child>
             <child>
-              <object class="HdyComboRow" id="custom_font_combo">
+              <object class="AdwComboRow" id="custom_font_combo">
                 <property name="title" translatable="yes">Use custom font</property>
                 <property name="subtitle" translatable="yes">Choose a font for the article view</property>
-                <property name="visible">True</property>
                 <child type="prefix">
                   <object class="GtkSwitch" id="custom_font_switch">
-                    <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="valign">center</property>
                   </object>
@@ -65,14 +57,12 @@
               </object>
             </child>
             <child>
-              <object class="HdyActionRow">
+              <object class="AdwActionRow">
                 <property name="title" translatable="yes">Preview popups in article links</property>
                 <property name="subtitle" translatable="yes">Show a preview of the article when hovering over a link</property>
-                <property name="visible">True</property>
                 <property name="activatable_widget">preview_popups_switch</property>
                 <child>
                   <object class="GtkSwitch" id="preview_popups_switch">
-                    <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="valign">center</property>
                   </object>
@@ -84,24 +74,20 @@
       </object>
     </child>
     <child>
-      <object class="HdyPreferencesPage">
-        <property name="visible">True</property>
+      <object class="AdwPreferencesPage">
         <property name="title" translatable="yes">Privacy</property>
         <property name="icon_name">preferences-system-privacy-symbolic</property>
         <child>
-          <object class="HdyPreferencesGroup">
-            <property name="visible">True</property>
+          <object class="AdwPreferencesGroup">
             <property name="can-focus">False</property>
             <property name="title" translatable="yes">Search</property>
             <child>
-              <object class="HdyActionRow">
+              <object class="AdwActionRow">
                 <property name="title" translatable="yes">Allow live search on desktop</property>
                 <property name="subtitle" translatable="yes">Warning: all desktop searches will be sent to Wikipedia</property>
-                <property name="visible">True</property>
                 <property name="activatable_widget">desktop_search_switch</property>
                 <child>
                   <object class="GtkSwitch" id="desktop_search_switch">
-                    <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="valign">center</property>
                   </object>
@@ -111,19 +97,16 @@
           </object>
         </child>
         <child>
-          <object class="HdyPreferencesGroup">
-            <property name="visible">True</property>
+          <object class="AdwPreferencesGroup">
             <property name="can-focus">False</property>
             <property name="title" translatable="yes">Personal Data</property>
             <child>
-              <object class="HdyActionRow">
+              <object class="AdwActionRow">
                 <property name="title" translatable="yes">Keep a list of recent articles</property>
                 <property name="subtitle" translatable="yes">Wike will remember the history of visited articles</property>
-                <property name="visible">True</property>
                 <property name="activatable_widget">historic_switch</property>
                 <child type="prefix">
                   <object class="GtkSwitch" id="historic_switch">
-                    <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="valign">center</property>
                   </object>
@@ -131,7 +114,6 @@
                 <child>
                   <object class="GtkButton" id="clear_historic_button">
                     <property name="label" translatable="yes">Clear</property>
-                    <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="valign">center</property>
                   </object>
@@ -139,14 +121,12 @@
               </object>
             </child>
             <child>
-              <object class="HdyActionRow">
+              <object class="AdwActionRow">
                 <property name="title" translatable="yes">Clear personal data</property>
                 <property name="subtitle" translatable="yes">Cookies and cache data will be deleted</property>
-                <property name="visible">True</property>
                 <child>
                   <object class="GtkButton" id="clear_data_button">
                     <property name="label" translatable="yes">Clear</property>
-                    <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="valign">center</property>
                   </object>
@@ -158,29 +138,21 @@
       </object>
     </child>
     <child>
-      <object class="HdyPreferencesPage">
-        <property name="visible">True</property>
+      <object class="AdwPreferencesPage">
         <property name="title" translatable="yes">Languages</property>
         <property name="icon_name">wike-flag-symbolic</property>
         <child>
-          <object class="HdyPreferencesGroup">
-            <property name="visible">True</property>
+          <object class="AdwPreferencesGroup">
             <property name="can-focus">False</property>
             <property name="title" translatable="yes">Filter Available Languages</property>
             <child>
               <object class="GtkScrolledWindow">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <property name="shadow_type">in</property>
                 <property name="propagate-natural-height">True</property>
                 <child>
                   <object class="GtkViewport">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
                     <child>
                       <object class="GtkListBox" id="languages_list">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
                       </object>
                     </child>
                   </object>
@@ -193,15 +165,15 @@
             </child>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+
+
                 <property name="spacing">12</property>
                 <property name="margin-top">12</property>
                 <property name="homogeneous">True</property>
                 <child>
                   <object class="GtkButton" id="select_all_button">
                     <property name="label" translatable="yes">Select All</property>
-                    <property name="visible">True</property>
+
                     <property name="can_focus">True</property>
                   </object>
                   <packing>
@@ -213,7 +185,7 @@
                 <child>
                   <object class="GtkButton" id="select_none_button">
                     <property name="label" translatable="yes">Select None</property>
-                    <property name="visible">True</property>
+
                     <property name="can_focus">True</property>
                   </object>
                   <packing>

--- a/data/ui/prefs.ui
+++ b/data/ui/prefs.ui
@@ -14,7 +14,6 @@
         <property name="icon_name">applications-system-symbolic</property>
         <child>
           <object class="AdwPreferencesGroup">
-            <property name="can-focus">False</property>
             <property name="title" translatable="yes">Behavior</property>
             <child>
               <object class="AdwComboRow" id="on_start_combo">

--- a/data/ui/search-row.ui
+++ b/data/ui/search-row.ui
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk" version="4.0"/>
   <template class="SearchLangBoxRow" parent="GtkListBoxRow">
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        
+        
         <child>
           <object class="GtkLabel" id="label_name">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            
+            
             <property name="halign">start</property>
-            <property name="margin_left">6</property>
-            <property name="margin_right">6</property>
+            <property name="margin_start">6</property>
+            <property name="margin_end">6</property>
             <property name="margin_top">6</property>
             <property name="margin_bottom">6</property>
           </object>
@@ -24,8 +24,8 @@
         </child>
         <child>
           <object class="GtkImage" id="image_check">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            
+            
             <property name="halign">start</property>
           </object>
           <packing>
@@ -36,11 +36,11 @@
         </child>
         <child>
           <object class="GtkLabel" id="label_id">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            
+            
             <property name="halign">end</property>
-            <property name="margin_left">6</property>
-            <property name="margin_right">6</property>
+            <property name="margin_start">6</property>
+            <property name="margin_end">6</property>
             <property name="margin_top">3</property>
             <property name="margin_bottom">3</property>
           </object>

--- a/data/ui/search-settings.ui
+++ b/data/ui/search-settings.ui
@@ -1,88 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk" version="4.0"/>
   <template class="SettingsPopover" parent="GtkPopover">
-    <property name="can_focus">False</property>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="border_width">10</property>
         <property name="orientation">vertical</property>
         <property name="spacing">8</property>
         <child>
           <object class="GtkSearchEntry" id="filter_entry">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkScrolledWindow">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="shadow_type">in</property>
             <property name="min_content_width">300</property>
             <property name="max_content_height">300</property>
             <property name="propagate_natural_height">True</property>
             <child>
               <object class="GtkViewport">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <child>
                   <object class="GtkListBox" id="languages_list">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
                   </object>
                 </child>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="spacing">8</property>
             <child>
               <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <property name="halign">start</property>
                 <property name="label" translatable="yes">Search suggestions</property>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkSwitch" id="suggestions_switch">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/data/ui/search.ui
+++ b/data/ui/search.ui
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk" version="4.0"/>
   <template class="SearchEntry" parent="GtkSearchEntry">
-    <property name="visible">False</property>
-    <property name="can_focus">True</property>
     <property name="max_width_chars">40</property>
-    <property name="primary_icon_name">emblem-system-symbolic</property>
-    <property name="primary_icon_activatable">True</property>
-    <property name="primary_icon_sensitive">True</property>
+    <!-- <property name="primary_icon_name">emblem-system-symbolic</property> -->
+    <!-- <property name="primary_icon_activatable">True</property> -->
+    <!-- <property name="primary_icon_sensitive">True</property> -->
   </template>
 </interface>
 

--- a/data/ui/shortcuts.ui
+++ b/data/ui/shortcuts.ui
@@ -1,69 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkShortcutsWindow" id="shortcuts_window">
     <property name="modal">True</property>
     <child>
       <object class="GtkShortcutsSection">
-        <property name="visible">True</property>
+        
         <property name="section-name">shortcuts</property>
         <property name="max-height">12</property>
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="visible">True</property>
+            
             <property name="title" translatable="yes" context="shortcut window">General</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Main menu</property>
                 <property name="accelerator">F10</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Table of contents</property>
                 <property name="accelerator">&lt;Primary&gt;T</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">View article in other languages</property>
                 <property name="accelerator">&lt;Primary&gt;L</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Search text in page</property>
                 <property name="accelerator">&lt;Primary&gt;F</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Preferences</property>
                 <property name="accelerator">&lt;Primary&gt;E</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Copy Wikipedia URL</property>
                 <property name="accelerator">&lt;Primary&gt;U</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Quit</property>
                 <property name="accelerator">&lt;Primary&gt;Q</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Keyboard shortcuts</property>
                 <property name="accelerator">&lt;Primary&gt;question</property>
               </object>
@@ -72,18 +72,18 @@
         </child>
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="visible">True</property>
+            
             <property name="title" translatable="yes" context="shortcut window">Bookmarks</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Show bookmarks</property>
                 <property name="accelerator">&lt;Primary&gt;B</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Add bookmark</property>
                 <property name="accelerator">&lt;Primary&gt;D</property>
               </object>
@@ -92,32 +92,32 @@
         </child>
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="visible">True</property>
+            
             <property name="title" translatable="yes" context="shortcut window">Tabs</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">New tab</property>
                 <property name="accelerator">&lt;Primary&gt;N</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Close current tab</property>
                 <property name="accelerator">&lt;Primary&gt;W</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Next tab</property>
                 <property name="accelerator">&lt;Primary&gt;Tab</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Previous tab</property>
                 <property name="accelerator">&lt;Shift&gt;&lt;Primary&gt;Tab</property>
               </object>
@@ -126,46 +126,46 @@
         </child>
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="visible">True</property>
+            
             <property name="title" translatable="yes" context="shortcut window">Navigation</property>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Search articles</property>
                 <property name="accelerator">F2 &lt;Primary&gt;K</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Wikipedia main page</property>
                 <property name="accelerator">&lt;Alt&gt;Home</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Show recent articles</property>
                 <property name="accelerator">&lt;Primary&gt;H</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Previous page</property>
                 <property name="accelerator">&lt;Alt&gt;Left</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Next page</property>
                 <property name="accelerator">&lt;Alt&gt;Right</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
-                <property name="visible">True</property>
+                
                 <property name="title" translatable="yes" context="shortcut window">Reload page</property>
                 <property name="accelerator">F5 &lt;Primary&gt;R</property>
               </object>

--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -1,101 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="3.24"/>
-  <requires lib="libhandy" version="1.0"/>
-  <template class="Window" parent="HdyApplicationWindow">
-    <property name="can_focus">False</property>
+  <requires lib="gtk" version="4.0"/>
+  <requires lib="libadwaita" version="1.0"/>
+  <template class="Window" parent="AdwApplicationWindow">
     <child>
       <object class="GtkBox" id="window_box">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkOverlay">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <child>
               <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="HdyTabBar" id="tabbar">
+                  <object class="AdwTabBar" id="tabbar">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="autohide">True</property>
                     <property name="expand-tabs">True</property>
                     <property name="view">tabview</property>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
-                  <object class="HdyTabView" id="tabview">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                  <object class="AdwTabView" id="tabview">
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="index">-1</property>
-              </packing>
             </child>
             <child type="overlay">
               <object class="GtkRevealer" id="notification">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">start</property>
                 <property name="transition_duration">500</property>
                 <property name="reveal_child">False</property>
                 <child>
                   <object class="GtkFrame">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="shadow_type">none</property>
                     <child>
                       <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
                         <property name="spacing">10</property>
                         <child>
                           <object class="GtkLabel" id="notification_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_left">8</property>
+                            <property name="margin_start">8</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkButton" id="notification_close_button">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="relief">none</property>
                             <child>
                               <object class="GtkImage">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
                                 <property name="icon_name">window-close-symbolic</property>
                               </object>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
                     </child>
@@ -107,11 +61,6 @@
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -13,8 +13,6 @@
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="AdwTabBar" id="tabbar">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
                     <property name="autohide">True</property>
                     <property name="expand-tabs">True</property>
                     <property name="view">tabview</property>

--- a/src/application.py
+++ b/src/application.py
@@ -114,7 +114,7 @@ class Application(Gtk.Application):
   def _prefs_cb(self, action, parameter):
     prefs_window = PrefsWindow()
     prefs_window.set_transient_for(self._window)
-    prefs_window.show_all()
+    prefs_window.present()
 
   # Set theme light for UI and view
 
@@ -150,8 +150,7 @@ class Application(Gtk.Application):
     builder.add_from_resource("/com/github/hugolabe/Wike/ui/about.ui")
     about_dialog = builder.get_object("about_dialog")
     about_dialog.set_transient_for(self._window)
-    about_dialog.run()
-    about_dialog.destroy()
+    about_dialog.present()
 
   # On window delete quit app
 

--- a/src/application.py
+++ b/src/application.py
@@ -105,9 +105,9 @@ class Application(Gtk.Application):
       self._gtk_settings = Gtk.Settings.get_default()
       if settings.get_int('theme') == 1:
         self._gtk_settings.set_property('gtk-application-prefer-dark-theme', True)
-        self._window.present()
     else:
       self._window.present()
+    self._window.show()
 
   # Show Preferences window
 
@@ -155,7 +155,7 @@ class Application(Gtk.Application):
 
   # On window delete quit app
 
-  def _window_delete_cb(self, window, event):
+  def _window_delete_cb(self, window):
     window.tabview.disconnect(window.handler_selpage)
     quit_action = self.lookup_action('quit')
     quit_action.activate()

--- a/src/application.py
+++ b/src/application.py
@@ -104,7 +104,7 @@ class Application(Gtk.Application):
       self._window.connect('close-request',self._window_delete_cb)
       self._gtk_settings = Gtk.Settings.get_default()
       if settings.get_int('theme') == 1:
-        self._gtk_settings.set_property('gtk-application-prefer-dark-theme', True)
+        Adw.StyleManager().get_default().set_color_scheme(Adw.ColorScheme.FORCE_LIGHT)
     else:
       self._window.present()
     self._window.show()
@@ -120,19 +120,19 @@ class Application(Gtk.Application):
 
   def _theme_light(self, action, parameter):
     settings.set_int('theme', 0)
-    self._gtk_settings.set_property('gtk-application-prefer-dark-theme', False)
+    Adw.StyleManager().get_default().set_color_scheme(Adw.ColorScheme.FORCE_LIGHT)
 
   # Set theme dark for UI and view
 
   def _theme_dark(self, action, parameter):
     settings.set_int('theme', 1)
-    self._gtk_settings.set_property('gtk-application-prefer-dark-theme', True)
+    Adw.StyleManager().get_default().set_color_scheme(Adw.ColorScheme.FORCE_DARK)
 
   # Set theme sepia for UI and view
 
   def _theme_sepia(self, action, parameter):
     settings.set_int('theme', 2)
-    self._gtk_settings.set_property('gtk-application-prefer-dark-theme', False)
+    Adw.StyleManager().get_default().set_color_scheme(Adw.ColorScheme.FORCE_LIGHT)
 
   # Show Shortcuts window
 

--- a/src/application.py
+++ b/src/application.py
@@ -18,16 +18,16 @@
 
 
 import sys
-
 import gi
-gi.require_version('Gtk', '3.0')
-gi.require_version('Handy', '1')
-from gi.repository import Gio, GLib, Gtk, Handy
+
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+
+from gi.repository import  Gtk, Gio, GLib, Adw
 
 from wike.data import settings, languages, historic, bookmarks
 from wike.prefs import PrefsWindow
 from wike.window import Window
-
 
 # Main application class
 # Wike Wikipedia Reader
@@ -49,7 +49,7 @@ class Application(Gtk.Application):
   def do_startup(self):
     Gtk.Application.do_startup(self)
 
-    Handy.init()
+    Adw.init()
 
     action = Gio.SimpleAction.new('prefs', None)
     action.connect('activate', self._prefs_cb)
@@ -101,11 +101,11 @@ class Application(Gtk.Application):
   def do_activate(self):
     if not self._window:
       self._window = Window(self, self._launch_uri)
-      self._window.connect('delete-event',self._window_delete_cb)
+      self._window.connect('close-request',self._window_delete_cb)
       self._gtk_settings = Gtk.Settings.get_default()
       if settings.get_int('theme') == 1:
         self._gtk_settings.set_property('gtk-application-prefer-dark-theme', True)
-      self._window.show_all()
+        self._window.present()
     else:
       self._window.present()
 

--- a/src/bookmarks.py
+++ b/src/bookmarks.py
@@ -18,7 +18,7 @@
 
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk
 
 from wike.data import languages, bookmarks
@@ -52,8 +52,8 @@ class BookmarksPopover(Gtk.Popover):
     self._populate()
 
     self.bookmarks_list.connect('row-activated', self._list_activated_cb)
-    self.bookmarks_list.connect('add', self._list_changed_cb)
-    self.bookmarks_list.connect('remove', self._list_changed_cb)
+    #self.bookmarks_list.connect('add', self._list_changed_cb)
+    #self.bookmarks_list.connect('remove', self._list_changed_cb)
     self.add_button.connect('clicked', self._add_button_clicked_cb)
     self.clear_button.connect('clicked', self._clear_button_clicked_cb)
     self.connect('show', self._popover_show_cb)

--- a/src/header.py
+++ b/src/header.py
@@ -112,12 +112,12 @@ class HeaderBar(Gtk.HeaderBar):
 
   def _search_button_cb(self, search_button):
     if search_button.get_active():
-      self.set_custom_title(self.search_entry)
+      self.set_title_widget(self.search_entry)
       self.search_entry.show()
       self.search_entry.grab_focus()
     else:
       self.search_entry.hide()
-      self.set_custom_title(None)
+      self.set_title_widget(None)
 
   # Enable or disable menu items on button toggled
 

--- a/src/header.py
+++ b/src/header.py
@@ -18,9 +18,9 @@
 
 
 import gi
-gi.require_version('Gtk', '3.0')
-gi.require_version('Handy', '1')
-from gi.repository import Gtk, Handy
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+from gi.repository import Gtk, Adw
 
 from wike.data import settings, historic
 from wike.bookmarks import BookmarksPopover
@@ -34,7 +34,7 @@ from wike.toc import TocPopover
 # Contains widgets for manage searchs, navigation and popovers
 
 @Gtk.Template(resource_path='/com/github/hugolabe/Wike/ui/header.ui')
-class HeaderBar(Handy.HeaderBar):
+class HeaderBar(Gtk.HeaderBar):
 
   __gtype_name__ = 'HeaderBar'
 
@@ -44,6 +44,7 @@ class HeaderBar(Handy.HeaderBar):
   bookmarks_button = Gtk.Template.Child()
   langlinks_button = Gtk.Template.Child()
   toc_button = Gtk.Template.Child()
+  window_title = Gtk.Template.Child()
 
   # Set main menu and connect signals and actions
 
@@ -57,6 +58,7 @@ class HeaderBar(Handy.HeaderBar):
     self.bookmarks_popover = BookmarksPopover(self._window)
     self.langlinks_popover = LanglinksPopover(self._window)
     self.toc_popover = TocPopover(self._window)
+    self.window_title = Gtk.Label()
 
     self.menu_button.set_popover(self.menu_popover)
     self.bookmarks_button.set_popover(self.bookmarks_popover)
@@ -64,7 +66,7 @@ class HeaderBar(Handy.HeaderBar):
     self.toc_button.set_popover(self.toc_popover)
 
     self.search_button.connect('clicked', self._search_button_cb)
-    self.menu_button.connect('toggled', self._menu_button_cb)
+    self.menu_button.connect('activate', self._menu_button_cb)
 
   # Populate toc popover
 
@@ -81,14 +83,15 @@ class HeaderBar(Handy.HeaderBar):
   # Populate langlinks popover
 
   def set_langlinks(self, langlinks):
-    if langlinks == None:
-      self.langlinks_popover.populate(None)
-    else:
-      if len(langlinks) > 0:
-        if self.langlinks_popover.populate(langlinks):
-          self.langlinks_button.set_sensitive(True)
-      else:
-        self.langlinks_popover.populate(None)
+      None
+    # if langlinks == None:
+    #   self.langlinks_popover.populate(None)
+    # else:
+    #   if len(langlinks) > 0:
+    #     if self.langlinks_popover.populate(langlinks):
+    #       self.langlinks_button.set_sensitive(True)
+    #   else:
+    #     self.langlinks_popover.populate(None)
 
   # Refresh_languages for settings and langlinks popovers
 
@@ -137,4 +140,6 @@ class HeaderBar(Handy.HeaderBar):
         show_historic_action.set_enabled(True)
       else:
         show_historic_action.set_enabled(False)
+
+
 

--- a/src/header.py
+++ b/src/header.py
@@ -44,7 +44,6 @@ class HeaderBar(Gtk.HeaderBar):
   bookmarks_button = Gtk.Template.Child()
   langlinks_button = Gtk.Template.Child()
   toc_button = Gtk.Template.Child()
-  window_title = Gtk.Template.Child()
 
   # Set main menu and connect signals and actions
 
@@ -58,7 +57,6 @@ class HeaderBar(Gtk.HeaderBar):
     self.bookmarks_popover = BookmarksPopover(self._window)
     self.langlinks_popover = LanglinksPopover(self._window)
     self.toc_popover = TocPopover(self._window)
-    self.window_title = Gtk.Label()
 
     self.menu_button.set_popover(self.menu_popover)
     self.bookmarks_button.set_popover(self.bookmarks_popover)

--- a/src/langlinks.py
+++ b/src/langlinks.py
@@ -18,7 +18,7 @@
 
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import GLib, Gtk
 
 from wike.data import languages

--- a/src/menu.py
+++ b/src/menu.py
@@ -18,7 +18,7 @@
 
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gio, Gdk, Gtk
 
 from wike.data import settings
@@ -46,7 +46,7 @@ class MenuPopover(Gtk.Popover):
     gfile = Gio.File.new_for_uri('resource:///com/github/hugolabe/Wike/ui/menu.css')
     css_provider = Gtk.CssProvider()
     css_provider.load_from_file(gfile)
-    Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
+    Gtk.StyleContext.add_provider_for_display(Gdk.Display.get_default(), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER)
     
     if settings.get_int('theme') == 1:
       self.dark_button.set_active(True)

--- a/src/page.py
+++ b/src/page.py
@@ -80,7 +80,7 @@ class PageBox(Gtk.Box):
       tabpage.set_title(_('Loading Article'))
       tabpage.set_loading(True)
       if tabpage.get_selected():
-        self._window.headerbar.window_title.set_label(_('Loading Article'))
+        self._window.set_title(_('Loading Article'))
         self._window.headerbar.toc_button.set_sensitive(False)
         self._window.headerbar.langlinks_button.set_sensitive(False)
         if self._window.headerbar.search_button.get_active():
@@ -89,7 +89,7 @@ class PageBox(Gtk.Box):
       wikiview.set_props()
       tabpage.set_title(wikiview.title)
       if tabpage.get_selected():
-        self._window.headerbar.window_title.set_label(wikiview.title)
+        self._window.set_title(wikiview.title)
         self._window.headerbar.set_toc(wikiview.sections)
         self._window.headerbar.set_langlinks(wikiview.langlinks)
     elif event == WebKit2.LoadEvent.FINISHED:

--- a/src/page.py
+++ b/src/page.py
@@ -49,6 +49,8 @@ class PageBox(Gtk.Box):
 
     self.wikiview = WikiView()
     self.append(self.wikiview)
+    self.wikiview.set_hexpand(True)
+    self.wikiview.set_vexpand(True)
     self.wikiview.show()
 
     find_controller = self.wikiview.get_find_controller()

--- a/src/page.py
+++ b/src/page.py
@@ -18,8 +18,8 @@
 
 
 import gi
-gi.require_version('Gtk', '3.0')
-gi.require_version('WebKit2', '4.0')
+gi.require_version('Gtk', '4.0')
+gi.require_version('WebKit2', '5.0')
 from gi.repository import Gdk, Gtk, WebKit2
 
 from wike.data import settings, historic
@@ -48,7 +48,7 @@ class PageBox(Gtk.Box):
     self._window = window
 
     self.wikiview = WikiView()
-    self.pack_end(self.wikiview, True, True, 0)
+    self.append(self.wikiview)
     self.wikiview.show()
 
     find_controller = self.wikiview.get_find_controller()
@@ -78,7 +78,7 @@ class PageBox(Gtk.Box):
       tabpage.set_title(_('Loading Article'))
       tabpage.set_loading(True)
       if tabpage.get_selected():
-        self._window.headerbar.set_title(_('Loading Article'))
+        self._window.headerbar.window_title.set_label(_('Loading Article'))
         self._window.headerbar.toc_button.set_sensitive(False)
         self._window.headerbar.langlinks_button.set_sensitive(False)
         if self._window.headerbar.search_button.get_active():
@@ -87,7 +87,7 @@ class PageBox(Gtk.Box):
       wikiview.set_props()
       tabpage.set_title(wikiview.title)
       if tabpage.get_selected():
-        self._window.headerbar.set_title(wikiview.title)
+        self._window.headerbar.window_title.set_label(wikiview.title)
         self._window.headerbar.set_toc(wikiview.sections)
         self._window.headerbar.set_langlinks(wikiview.langlinks)
     elif event == WebKit2.LoadEvent.FINISHED:

--- a/src/prefs.py
+++ b/src/prefs.py
@@ -18,10 +18,11 @@
 
 
 import gi
-gi.require_version('Gtk', '3.0')
-gi.require_version('Handy', '1')
-gi.require_version('WebKit2', '4.0')
-from gi.repository import Gio, Gtk, Handy, WebKit2
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+gi.require_version('WebKit2', '5.0')
+
+from gi.repository import Gio, Gtk, Adw, WebKit2
 
 from wike.data import settings, languages, historic
 
@@ -30,7 +31,7 @@ from wike.data import settings, languages, historic
 # Manage application preferences
 
 @Gtk.Template(resource_path='/com/github/hugolabe/Wike/ui/prefs.ui')
-class PrefsWindow(Handy.PreferencesWindow):
+class PrefsWindow(Adw.PreferencesWindow):
 
   __gtype_name__ = 'PrefsWindow'
 
@@ -76,16 +77,16 @@ class PrefsWindow(Handy.PreferencesWindow):
   # Populate list of available options for start page
 
   def _populate_on_start_combo(self):
-    model = Gio.ListStore.new(Handy.ValueObject)
+    model = Gio.ListStore.new(Adw.ValueObject)
     options = (_('Wikipedia Main Page'), _('Random Article'), _('Last Article'))
     for index, option in enumerate(options):
-      model.insert(index, Handy.ValueObject.new(option))
-    self.on_start_combo.bind_name_model(model, Handy.ValueObject.dup_string)
+      model.insert(index, Adw.ValueObject.new(option))
+    self.on_start_combo.bind_name_model(model, Adw.ValueObject.dup_string)
 
   # Populate font list for custom font combo
 
   def _populate_custom_font_combo(self):
-    model = Gio.ListStore.new(Handy.ValueObject)
+    model = Gio.ListStore.new(Adw.ValueObject)
     fonts = []
     custom_font = settings.get_string('font-family')
     pango_context = self.get_pango_context()
@@ -94,10 +95,10 @@ class PrefsWindow(Handy.PreferencesWindow):
     fonts.sort(key=str.lower)
     selected = 0
     for index, font in enumerate(fonts):
-      model.insert(index, Handy.ValueObject.new(font))
+      model.insert(index, Adw.ValueObject.new(font))
       if font == custom_font:
         selected = index
-    self.custom_font_combo.bind_name_model(model, Handy.ValueObject.dup_string)
+    self.custom_font_combo.bind_name_model(model, Adw.ValueObject.dup_string)
     self.custom_font_combo.set_selected_index(selected)
 
   # Populate list of available languages

--- a/src/search.py
+++ b/src/search.py
@@ -20,12 +20,11 @@
 from threading import Thread
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gio, GLib, Gtk
 
 from wike import wikipedia
 from wike.data import settings, languages
-
 
 # Search entry class
 # Manage article searchs in Wikipedia
@@ -42,17 +41,18 @@ class SearchEntry(Gtk.SearchEntry):
 
     self.window = window
 
-    self.settings_popover = SettingsPopover(self)
-    self.suggestions_popover = SuggestionsPopover(self)
+    # self.settings_popover = SettingsPopover(self)
+    # self.suggestions_popover = SuggestionsPopover(self)
     self.results_list = None
     self._results_changed = False
 
     lang_id = settings.get_string('search-language')
-    self.set_icon_tooltip_text(Gtk.EntryIconPosition.PRIMARY, languages.wikilangs[lang_id].capitalize())
+    #self.set_icon_tooltip_text(Gtk.EntryIconPosition.PRIMARY, languages.wikilangs[lang_id].capitalize())
 
     self.connect('show', self._entry_show_cb)
-    self.connect('key-press-event', self._key_press_cb, search_button)
-    self.connect('icon-release',self._icon_release_cb)
+    # TODO: Use EventControllerKey
+    #self.connect('key-press-event', self._key_press_cb, search_button)
+    #self.connect('icon-release',self._icon_release_cb)
 
   # Search text in Wikipedia and load results list
 
@@ -66,8 +66,8 @@ class SearchEntry(Gtk.SearchEntry):
   # When entry show add timeout function
 
   def _entry_show_cb(self, entry):
-    if self.suggestions_popover.is_visible():
-      self.suggestions_popover.hide()
+    #if self.suggestions_popover.is_visible():
+    #  self.suggestions_popover.hide()
 
     if settings.get_boolean('search-suggestions'):
       GLib.timeout_add(250, self._timeout_cb)
@@ -79,12 +79,12 @@ class SearchEntry(Gtk.SearchEntry):
       return False
 
     if self._results_changed:
-      if self.results_list != None:
-        self.suggestions_popover.populate(self.results_list)
-        if not self.suggestions_popover.is_visible():
-          self.suggestions_popover.show_all()
-      else:
-        self.suggestions_popover.hide()
+      #if self.results_list != None:
+        # self.suggestions_popover.populate(self.results_list)
+        # if not self.suggestions_popover.is_visible():
+        #   self.suggestions_popover.show_all()
+      #else:
+        # self.suggestions_popover.hide()
       self._results_changed = False
     return True
 
@@ -92,22 +92,23 @@ class SearchEntry(Gtk.SearchEntry):
 
   def _key_press_cb(self, entry, event, search_button):
     if event.keyval == 65364:
-      if self.suggestions_popover.is_visible():
-        self.suggestions_popover.grab_focus()
+      #if self.suggestions_popover.is_visible():
+      #  self.suggestions_popover.grab_focus()
       return True
     elif event.keyval == 65307:
-      if self.suggestions_popover.is_visible():
-        self.suggestions_popover.hide()
-      else:
+      #if self.suggestions_popover.is_visible():
+      #  self.suggestions_popover.hide()
+      #else:
         search_button.set_active(False)
 
   # Show settings popover on icon clicked
 
   def _icon_release_cb(self, entry, icon_pos, event):
-    if icon_pos == Gtk.EntryIconPosition.PRIMARY:
-      if self.suggestions_popover.is_visible():
-        self.suggestions_popover.hide()
-      self.settings_popover.show_all()
+    #if icon_pos == Gtk.EntryIconPosition.PRIMARY:
+    None
+      #if self.suggestions_popover.is_visible():
+      #  self.suggestions_popover.hide()
+      # self.settings_popover.show_all()
 
   # When text changes run search in new thread
 
@@ -147,7 +148,7 @@ class SuggestionsPopover(Gtk.Popover):
 
   def __init__(self, search_entry):
     super().__init__()
-    self.set_relative_to(search_entry)
+    # self.set_relative_to(search_entry)
     self.set_size_request(360, -1)
     self.set_modal(False)
 
@@ -160,14 +161,14 @@ class SuggestionsPopover(Gtk.Popover):
     action = Gio.SimpleAction.new('suggestion', GLib.VariantType('s'))
     action.connect('activate', self._suggestion_activate_cb)
     actions.add_action(action)
-    self.insert_action_group('suggestions_popover', actions)
+    #self.insert_action_group('suggestions_popover', actions)
 
   # Populate search results list
 
   def populate(self, results_list):
     self._results_menu.remove_all()
     for index, item in enumerate(results_list[0]):
-      action_string = 'suggestions_popover.suggestion(\'' + str(index) + '\')'
+      #action_string = 'suggestions_popover.suggestion(\'' + str(index) + '\')'
       button = Gio.MenuItem.new(item, action_string)
       self._results_menu.append_item(button)
 
@@ -175,7 +176,7 @@ class SuggestionsPopover(Gtk.Popover):
 
   def do_key_press_event(self, event):
     if event.keyval == 65307:
-      search_entry = self.get_relative_to()
+      # search_entry = self.get_relative_to()
       search_entry.grab_focus_without_selecting()
       self.hide()
 
@@ -183,7 +184,7 @@ class SuggestionsPopover(Gtk.Popover):
 
   def _suggestion_activate_cb(self, action, parameter):
     index = int(parameter.unpack())
-    search_entry = self.get_relative_to()
+    # search_entry = self.get_relative_to()
     uri = search_entry.results_list[1][index]
     self._window.page.wikiview.load_wiki(uri)
 
@@ -204,7 +205,7 @@ class SettingsPopover(Gtk.Popover):
 
   def __init__(self, search_entry):
     super().__init__()
-    self.set_relative_to(search_entry)
+    # self.set_relative_to(search_entry)
 
     self._window = search_entry.window
 
@@ -252,7 +253,7 @@ class SettingsPopover(Gtk.Popover):
   # Change search language on list activated
 
   def _languages_list_activated_cb(self, lang_list, row):
-    search_entry = self.get_relative_to()
+    # search_entry = self.get_relative_to()
     search_entry.set_icon_tooltip_text(Gtk.EntryIconPosition.PRIMARY, languages.wikilangs[row.lang_id].capitalize())
     settings.set_string('search-language', row.lang_id)
     wikipedia.set_lang(row.lang_id)

--- a/src/toc.py
+++ b/src/toc.py
@@ -18,7 +18,7 @@
 
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gio, GLib, Gtk
 
 
@@ -46,7 +46,7 @@ class TocPopover(Gtk.Popover):
   def populate(self, toc):
     self._toc = toc
     menu = Gio.Menu()
-    self.bind_model(menu, None)
+    self.set_child(Gtk.PopoverMenu.new_from_model(menu))
     if toc != None:
       self._fill_menu(menu, toc, 0)
 

--- a/src/view.py
+++ b/src/view.py
@@ -20,8 +20,8 @@
 import urllib.parse
 
 import gi
-gi.require_version('Gtk', '3.0')
-gi.require_version('WebKit2', '4.0')
+gi.require_version('Gtk', '4.0')
+gi.require_version('WebKit2', '5.0')
 from gi.repository import Gio, GLib, GObject, Gdk, Gtk, WebKit2
 
 from wike import wikipedia

--- a/src/window.py
+++ b/src/window.py
@@ -169,7 +169,7 @@ class Window(Adw.ApplicationWindow):
 
     self.page = tabpage.get_child()
     self.refresh_nav_buttons(self.page.wikiview)
-    self.headerbar.set_title(self.page.wikiview.title)
+    self.set_title(self.page.wikiview.title)
     self.headerbar.toc_button.set_sensitive(False)
     self.headerbar.langlinks_button.set_sensitive(False)
     self.headerbar.set_toc(self.page.wikiview.sections)
@@ -179,7 +179,7 @@ class Window(Adw.ApplicationWindow):
 
   def _tabview_close_page_cb(self, tabview, tabpage):
     page = tabpage.get_child()
-    page.wikiview.destroy()
+    #page.wikiview.destroy()
     tabview.close_page_finish(tabpage, True)
     return True
 

--- a/src/window.py
+++ b/src/window.py
@@ -18,9 +18,9 @@
 
 
 import gi
-gi.require_version('Gtk', '3.0')
-gi.require_version('Handy', '1')
-from gi.repository import Gio, GLib, Gdk, Gtk, Handy
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+from gi.repository import Gio, GLib, Gdk, Gtk, Adw
 
 from wike.data import settings
 from wike.header import HeaderBar
@@ -31,7 +31,7 @@ from wike.page import PageBox
 # Contains a page and a headerbar
 
 @Gtk.Template(resource_path='/com/github/hugolabe/Wike/ui/window.ui')
-class Window(Handy.ApplicationWindow):
+class Window(Adw.ApplicationWindow):
 
   __gtype_name__ = 'Window'
 
@@ -58,7 +58,7 @@ class Window(Handy.ApplicationWindow):
     tabpage = self.tabview.append(self.page)
 
     self.headerbar = HeaderBar(self)
-    self.window_box.pack_start(self.headerbar, False, True, 0)
+    self.window_box.prepend(self.headerbar)
 
     actions = [ ('prev_page', self._prev_page_cb, ('<Alt>Left',)),
                 ('next_page', self._next_page_cb, ('<Alt>Right',)),


### PR DESCRIPTION
Very hacky and incredibly broken so far.
![image](https://user-images.githubusercontent.com/27908024/143732860-fbd1a45d-1f65-43dd-9b45-f9464700d88e.png)

TODO/FIX:
- [ ] **Search doesn't work**
-  On the topic of the search entry, GTK4 doesn't accept attaching popovers to arbitary widgets, so that should also be figured out.
- Furthermore, the input is broken right now in GNOME SDK/Platform, so I can't even test it
- [ ] **Table of contents is empty**
- [ ] **Language picker doesn't work**
- [ ] **Preferences dialog doesn't work**
- This requires porting away from Hdy.ValueObject.
- [ ] **Crashes on right click**
- [x] **About dialog doesn't work**
- [ ] **Cannot add bookmark** 
- [ ] Use GdkClipboard
- [ ] Stop destroying widgets
- [x] Window title isn't set properly
- [ ] Stop using `gtk-application-prefer-dark-theme`, opt-in to dark style preference (needs design)
- [ ] Webview is invisible in dark mode