### PR TITLE
Add some simple vim-like navigation 

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -60,11 +60,10 @@ class Window(Handy.ApplicationWindow):
     self.headerbar = HeaderBar(self)
     self.window_box.pack_start(self.headerbar, False, True, 0)
 
-    actions = [ ('prev_page', self._prev_page_cb, ('<Alt>Left','<Shift>H',)),
-                ('next_page', self._next_page_cb, ('<Alt>Right','<Shift>L',)),
+    actions = [ ('prev_page', self._prev_page_cb, ('<Alt>Left','h',)),
+                ('next_page', self._next_page_cb, ('<Alt>Right','l',)),
                 ('scroll_down', self._scroll_down, ('j',)),
                 ('scroll_up', self._scroll_up, ('k',)),
-                ('next_page', self._next_page_cb, ('<Alt>Right','<Shift>L',)),
                 ('new_tab', self._new_tab_cb, ('<Ctrl>N',)),
                 ('close_tab', self._close_tab_cb, ('<Ctrl>W',)),
                 ('next_tab', self._next_tab_cb, ('<Ctrl>Tab',)),

--- a/src/window.py
+++ b/src/window.py
@@ -60,8 +60,11 @@ class Window(Handy.ApplicationWindow):
     self.headerbar = HeaderBar(self)
     self.window_box.pack_start(self.headerbar, False, True, 0)
 
-    actions = [ ('prev_page', self._prev_page_cb, ('<Alt>Left',)),
-                ('next_page', self._next_page_cb, ('<Alt>Right',)),
+    actions = [ ('prev_page', self._prev_page_cb, ('<Alt>Left','<Shift>H',)),
+                ('next_page', self._next_page_cb, ('<Alt>Right','<Shift>L',)),
+                ('scroll_down', self._scroll_down, ('j',)),
+                ('scroll_up', self._scroll_up, ('k',)),
+                ('next_page', self._next_page_cb, ('<Alt>Right','<Shift>L',)),
                 ('new_tab', self._new_tab_cb, ('<Ctrl>N',)),
                 ('close_tab', self._close_tab_cb, ('<Ctrl>W',)),
                 ('next_tab', self._next_tab_cb, ('<Ctrl>Tab',)),
@@ -119,6 +122,16 @@ class Window(Handy.ApplicationWindow):
 
     if select:
       self.tabview.set_selected_page(tabpage)
+
+  # Scroll down
+
+  def _scroll_down(self, action, parameter):
+    self.page.wikiview.run_javascript("window.scrollBy(0,50)",None,None,None)
+
+  # Scroll up
+
+  def _scroll_up(self, action, parameter):
+    self.page.wikiview.run_javascript('window.scrollBy(0,-50)',None,None,None)
 
   # New empty tab
 


### PR DESCRIPTION
I'm inexperienced when it comes to programming in Gtk, but I found a way to implement vim-like keybindings into Wike. I just add the following keybinds:
 - `h` to go to the previous page
 - `j` to scroll down by 50 pixels
 - `k` to scroll up by 50 pixels
 - `l` to go to the next page

I suspect there are better ways to achieve what I want to do using the Gtk API, but for my purposes, I've found a way to hack it together with `wikiview.run_javascript`.

I'd be happy to work on more properly implementing this feature, given some pointers