### PR TITLE
Add random article shortcut

### DIFF
--- a/data/ui/shortcuts.ui
+++ b/data/ui/shortcuts.ui
@@ -7,7 +7,6 @@
       <object class="GtkShortcutsSection">
         <property name="visible">True</property>
         <property name="section-name">shortcuts</property>
-        <property name="max-height">12</property>
         <child>
           <object class="GtkShortcutsGroup">
             <property name="visible">True</property>
@@ -140,6 +139,13 @@
                 <property name="visible">True</property>
                 <property name="title" translatable="yes" context="shortcut window">Wikipedia main page</property>
                 <property name="accelerator">&lt;Alt&gt;Home</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
+                <property name="title" translatable="yes" context="shortcut window">Random article</property>
+                <property name="accelerator">&lt;Alt&gt;R</property>
               </object>
             </child>
             <child>

--- a/src/window.py
+++ b/src/window.py
@@ -73,7 +73,7 @@ class Window(Handy.ApplicationWindow):
                 ('show_langlinks', self._show_langlinks_cb, ('<Ctrl>L',)),
                 ('show_toc', self._show_toc_cb, ('<Ctrl>T',)),
                 ('main_page', self._main_page_cb, ('<Alt>Home',)),
-                ('random_article', self._random_article_cb, None),
+                ('random_article', self._random_article_cb, ('<Alt>R',)),
                 ('show_historic', self._show_historic_cb, ('<Ctrl>H',)),
                 ('reload_page', self._reload_page_cb, ('F5', '<Ctrl>R',)),
                 ('search_text', self._search_text_cb, ('<Ctrl>F',)),


### PR DESCRIPTION
I chose `Alt+R` to be consistent with the `Alt+Home` shortcut. `Ctrl+R` is already in use. I also removed the `max-height` property to prevent the "Navigation" section from being displayed in a different tab:

![Captura de tela de 2022-11-18 21-28-47](https://user-images.githubusercontent.com/66979446/202824546-c4a80628-f15d-4aee-a5fb-4396a2659824.png)

I could increase the `max-height` to 13 or 14, but it doesn't seem necessary to have it.

Closes #95 