### PR TITLE
data: Add bugtracker to metainfo

### DIFF
--- a/data/com.github.hugolabe.Wike.metainfo.xml.in
+++ b/data/com.github.hugolabe.Wike.metainfo.xml.in
@@ -328,6 +328,7 @@
   </releases>
 
   <url type="homepage">https://hugolabe.github.io/Wike/</url>
+  <url type="bugtracker">https://github.com/hugolabe/Wike/issues</url>
   <url type="translate">https://poeditor.com/join/project?hash=kNgJu4MAum</url>
   <developer_name>Hugo Olabera</developer_name>
   <update_contact>hugolabe@gmail.com</update_contact>


### PR DESCRIPTION
This will also help apps.gnome.org and other GNOME tools to automatically collect data