### PR TITLE
Refactor Python imports

### DIFF
--- a/src/application.py
+++ b/src/application.py
@@ -9,6 +9,7 @@ import gi
 gi.require_version('Gdk', '4.0')
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
+gi.require_version('WebKit', '6.0')
 from gi.repository import GLib, Gio, Gdk, Gtk, Adw
 
 from wike.data import settings, languages, history, bookmarks

--- a/src/bookmarks.py
+++ b/src/bookmarks.py
@@ -3,9 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-import gi
-gi.require_version('Gtk', '4.0')
-gi.require_version('Adw', '1')
 from gi.repository import GObject, Gio, Gtk, Adw, Pango
 
 from wike.data import languages, bookmarks

--- a/src/data.py
+++ b/src/data.py
@@ -6,7 +6,6 @@
 import json
 from datetime import datetime
 
-import gi
 from gi.repository import GLib, Gio
 
 

--- a/src/header.py
+++ b/src/header.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-import gi
-gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk
 
 from wike.menu import MainMenuPopover, ViewMenuPopover

--- a/src/history.py
+++ b/src/history.py
@@ -5,9 +5,6 @@
 
 from datetime import datetime
 
-import gi
-gi.require_version('Gtk', '4.0')
-gi.require_version('Adw', '1')
 from gi.repository import GObject, Gio, Gtk, Adw
 
 from wike.data import settings, languages, history

--- a/src/langlinks.py
+++ b/src/langlinks.py
@@ -5,9 +5,6 @@
 
 import json
 
-import gi
-gi.require_version('Gtk', '4.0')
-gi.require_version('Adw', '1')
 from gi.repository import GLib, Gio, Gtk, Adw
 
 from wike.data import settings, languages

--- a/src/languages.py
+++ b/src/languages.py
@@ -3,9 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-import gi
-gi.require_version('Gtk', '4.0')
-gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw
 
 from wike.data import languages

--- a/src/menu.py
+++ b/src/menu.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-import gi
-gi.require_version('Gtk', '4.0')
 from gi.repository import GLib, Gio, Gtk, Pango
 
 from wike.data import settings

--- a/src/page.py
+++ b/src/page.py
@@ -3,9 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-import gi
-gi.require_version('Gtk', '4.0')
-gi.require_version('WebKit', '6.0')
 from gi.repository import Gtk, WebKit
 
 from wike.data import settings

--- a/src/prefs.py
+++ b/src/prefs.py
@@ -3,10 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-import gi
-gi.require_version('Gtk', '4.0')
-gi.require_version('Adw', '1')
-gi.require_version('WebKit', '6.0')
 from gi.repository import Gio, Gtk, Adw, WebKit
 
 from wike.data import settings

--- a/src/search.py
+++ b/src/search.py
@@ -5,8 +5,6 @@
 
 from threading import Thread
 
-import gi
-gi.require_version('Gtk', '4.0')
 from gi.repository import GLib, Gio, Gtk
 
 from wike import wikipedia

--- a/src/toc.py
+++ b/src/toc.py
@@ -5,9 +5,6 @@
 
 import json, urllib.parse
 
-import gi
-gi.require_version('Gtk', '4.0')
-gi.require_version('Adw', '1')
 from gi.repository import GLib, Gtk, Adw
 
 

--- a/src/view.py
+++ b/src/view.py
@@ -5,10 +5,6 @@
 
 import urllib.parse
 
-import gi
-gi.require_version('Gdk', '4.0')
-gi.require_version('Gtk', '4.0')
-gi.require_version('WebKit', '6.0')
 from gi.repository import GLib, GObject, Gio, Gdk, Gtk, Adw, WebKit
 
 from wike import wikipedia

--- a/src/window.py
+++ b/src/window.py
@@ -5,11 +5,6 @@
 
 import os
 
-import gi
-gi.require_version('Gdk', '4.0')
-gi.require_version('Gtk', '4.0')
-gi.require_version('Adw', '1')
-gi.require_version('WebKit', '6.0')
 from gi.repository import GLib, Gio, Gdk, Gtk, Adw, WebKit
 
 from wike.data import settings


### PR DESCRIPTION
As far as I know, `gi.require_version()` only needs to be specified in `application.py`. All the other files inherit the version request.