### PR TITLE
[v2] decouple flap state from pin-sidebar action to restore pinned state after re-expanding window

### DIFF
--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -49,20 +49,26 @@ SPDX-License-Identifier: GPL-3.0-or-later
                         </style>
                         <child>
                           <object class="GtkBox">
+                            <property name="hexpand">False</property>
                             <child>
-                              <object class="GtkToggleButton" id="flap_pin_button">
-                                <property name="icon-name">view-pin-symbolic</property>
-                                <property name="tooltip-text" translatable="yes">Pin Sidebar</property>
-                                <property name="margin-start">5</property>
-                                <property name="margin-end">5</property>
-                                <property name="margin-top">5</property>
-                                <property name="margin-bottom">5</property>
-                                <property name="valign">center</property>
-                                <property name="action-name">win.pin-sidebar</property>
-                                <style>
-                                  <class name="circular"/>
-                                  <class name="pin-button"/>
-                                </style>
+                              <object class="GtkRevealer" id="flap_pin_button_revealer">
+                                <property name="transition-type">slide-left</property>
+                                <child>
+                                  <object class="GtkToggleButton" id="flap_pin_button">
+                                    <property name="icon-name">view-pin-symbolic</property>
+                                    <property name="tooltip-text" translatable="yes">Pin Sidebar</property>
+                                    <property name="margin-start">5</property>
+                                    <property name="margin-end">5</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="valign">center</property>
+                                    <property name="action-name">win.pin-sidebar</property>
+                                    <style>
+                                      <class name="circular"/>
+                                      <class name="pin-button"/>
+                                    </style>
+                                  </object>
+                                </child>
                               </object>
                             </child>
                             <child>
@@ -72,11 +78,12 @@ SPDX-License-Identifier: GPL-3.0-or-later
                                 <property name="margin-top">5</property>
                                 <property name="margin-bottom">5</property>
                                 <property name="spacing">5</property>
+                                <property name="hexpand">True</property>
+                                <property name="homogeneous">True</property>
                                 <child>
                                   <object class="GtkToggleButton" id="flap_toc_button">
                                     <property name="icon-name">sidebar-toc-symbolic</property>
                                     <property name="tooltip-text" translatable="yes">Contents</property>
-                                    <property name="width-request">64</property>
                                     <style>
                                       <class name="flat"/>
                                     </style>
@@ -86,7 +93,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
                                   <object class="GtkToggleButton" id="flap_langlinks_button">
                                     <property name="icon-name">sidebar-langlinks-symbolic</property>
                                     <property name="tooltip-text" translatable="yes">Languages</property>
-                                    <property name="width-request">64</property>
                                     <property name="group">flap_toc_button</property>
                                     <style>
                                       <class name="flat"/>
@@ -97,7 +103,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
                                   <object class="GtkToggleButton" id="flap_bookmarks_button">
                                     <property name="icon-name">sidebar-bookmarks-symbolic</property>
                                     <property name="tooltip-text" translatable="yes">Bookmarks</property>
-                                    <property name="width-request">64</property>
                                     <property name="group">flap_toc_button</property>
                                     <style>
                                       <class name="flat"/>
@@ -108,7 +113,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
                                   <object class="GtkToggleButton" id="flap_history_button">
                                     <property name="icon-name">sidebar-history-symbolic</property>
                                     <property name="tooltip-text" translatable="yes">History</property>
-                                    <property name="width-request">64</property>
                                     <property name="group">flap_toc_button</property>
                                     <style>
                                       <class name="flat"/>

--- a/src/window.py
+++ b/src/window.py
@@ -181,11 +181,12 @@ class Window(Adw.ApplicationWindow):
 
     if self.mobile_layout:
       self.headerbar.set_mobile(True)
-      pin_sidebar_action.change_state(GLib.Variant.new_boolean(False))
       pin_sidebar_action.set_enabled(False)
     else:
       self.headerbar.set_mobile(False)
       pin_sidebar_action.set_enabled(True)
+
+    self._update_sidebar_pinned()
 
   # Create new tab with a page
 
@@ -326,8 +327,12 @@ class Window(Adw.ApplicationWindow):
   
   def _pin_sidebar_cb(self, action, parameter):
     action.set_state(parameter)
+    self._update_sidebar_pinned()
     
-    if parameter:
+  def _update_sidebar_pinned(self):
+    pin_sidebar_action = self.lookup_action('pin-sidebar')
+    prefer_pinned = pin_sidebar_action.get_state().get_boolean()
+    if prefer_pinned and not self.mobile_layout:
       self.flap.set_fold_policy(Adw.FlapFoldPolicy.NEVER)
     else:
       self.flap.set_fold_policy(Adw.FlapFoldPolicy.ALWAYS)

--- a/src/window.py
+++ b/src/window.py
@@ -5,7 +5,7 @@
 
 import os
 
-from gi.repository import GLib, Gio, Gdk, Gtk, Adw, WebKit
+from gi.repository import GLib, GObject, Gio, Gdk, Gtk, Adw, WebKit
 
 from wike.data import settings
 from wike.bookmarks import BookmarksBox
@@ -27,6 +27,7 @@ class Window(Adw.ApplicationWindow):
   toast_overlay = Gtk.Template.Child()
   flap = Gtk.Template.Child()
   flap_stack = Gtk.Template.Child()
+  flap_pin_button_revealer = Gtk.Template.Child()
   flap_pin_button = Gtk.Template.Child()
   flap_toc_button = Gtk.Template.Child()
   flap_langlinks_button = Gtk.Template.Child()
@@ -90,6 +91,8 @@ class Window(Adw.ApplicationWindow):
 
     self._set_actions(app)
     self._set_layout()
+
+    self.lookup_action('pin-sidebar').bind_property('enabled', self.flap_pin_button_revealer, 'reveal-child',  GObject.BindingFlags.SYNC_CREATE)
 
     self.handler_selpage = self.tabview.connect('notify::selected-page', self._tabview_selected_page_cb)
     self.tabview.connect('close-page', self._tabview_close_page_cb)


### PR DESCRIPTION
This is a follow-up to #118.

> The pin-sidebar action's state, being user intend for a pinned sidebar, can and will be overruled for lack of space. Currently, this overruling is made permanent, so shrinking the window and re-expanding it will result in the previously pinned sidebar to not be pinned anymore.
> 
> With decoupling the flap state from the pin-sidebar action, this overruling is made temporary with the user's previous setting restored.
> 
> As a follow-up, the button to pin the sidebar is when disabled of no use, and could even confuse due to the button's state not reflecting the sidebar's state. To solve this confusion, the button can be hidden, when the sidebar is forced into the collapsed mode on smaller screens or window widths.

changes since v1:
* sidebar page toggle buttons are now of variable width
* sidebar pin button uses revealer with animation

[wike-pin-sidebar.webm](https://user-images.githubusercontent.com/2989008/233196751-efc258be-033b-429f-835f-6daddf0426d9.webm)
