### PR TITLE
close unnecessary $HOME hole in sandbox

### DIFF
--- a/build-aux/flatpak/com.github.hugolabe.Wike.json
+++ b/build-aux/flatpak/com.github.hugolabe.Wike.json
@@ -10,8 +10,7 @@
     "--socket=fallback-x11",
     "--socket=wayland",
     "--socket=pulseaudio",
-    "--device=dri",
-    "--filesystem=home"
+    "--device=dri"
   ],
   "modules" : [
     "python3-dbus-python.json",


### PR DESCRIPTION
Wike does not need access to `$HOME` as it merely opens files `$XDG_DATA_HOME` that inside the flatpak sandbox is assured to be set to an accessible path.

Or am I mistaken? I did check the source code and am using Wike now with this hole closed and tried to test everything I know of you could do with it, but maybe I just didn't find the part, where this hole is needed.