### PR TITLE
Add option to clear cache and cookies when Wike is closed

### DIFF
--- a/data/com.github.hugolabe.Wike.gschema.xml
+++ b/data/com.github.hugolabe.Wike.gschema.xml
@@ -22,6 +22,11 @@
       <summary>Keep a list of recent articles</summary>
     </key>
 
+    <key name="clear-data-on-close" type="b">
+      <default>false</default>
+      <summary>Clear cookies and cache data when Wike is closed</summary>
+    </key>
+
     <key name="on-start-load" type="i">
       <default>0</default>
       <summary>On start load this page (0-Main, 1-Random, 2-Last)</summary>

--- a/data/ui/prefs.ui
+++ b/data/ui/prefs.ui
@@ -73,8 +73,14 @@ SPDX-License-Identifier: GPL-3.0-or-later
             </child>
             <child>
               <object class="AdwActionRow">
-                <property name="title" translatable="yes">Clear Personal Data</property>
-                <property name="subtitle" translatable="yes">Cookies and cache data will be deleted</property>
+                <property name="title" translatable="yes">Clear Personal Data on Close</property>
+                <property name="subtitle" translatable="yes">Cookies and cache data will be deleted when you exit Wike</property>
+                <property name="activatable-widget">data_switch</property>
+                <child type="prefix">
+                  <object class="GtkSwitch" id="data_switch">
+                    <property name="valign">center</property>
+                  </object>
+                </child>
                 <child>
                   <object class="GtkButton" id="clear_data_button">
                     <property name="label" translatable="yes">Clear</property>

--- a/src/application.py
+++ b/src/application.py
@@ -187,8 +187,10 @@ class Application(Adw.Application):
 
     settings.sync()
     languages.save()
+
     if not settings.get_boolean('keep-history'):
       history.clear()
+
     if settings.get_boolean('clear-data-on-close'):
       data_manager = network_session.get_website_data_manager()
       data_manager.clear(WebKit.WebsiteDataTypes.ALL, 0, None, None, None)

--- a/src/application.py
+++ b/src/application.py
@@ -10,11 +10,12 @@ gi.require_version('Gdk', '4.0')
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 gi.require_version('WebKit', '6.0')
-from gi.repository import GLib, Gio, Gdk, Gtk, Adw
+from gi.repository import GLib, Gio, Gdk, Gtk, Adw, WebKit
 
 from wike.data import settings, languages, history, bookmarks
 from wike.prefs import PrefsWindow
 from wike.window import Window
+from wike.view import network_session
 
 
 # Main application class for Wike
@@ -188,6 +189,10 @@ class Application(Adw.Application):
     languages.save()
     if not settings.get_boolean('keep-history'):
       history.clear()
+    if settings.get_boolean('clear-data-on-close'):
+      data_manager = network_session.get_website_data_manager()
+      data_manager.clear(WebKit.WebsiteDataTypes.ALL, 0, None, None, None)
+
     history.save()
     bookmarks.save()
 

--- a/src/prefs.py
+++ b/src/prefs.py
@@ -20,6 +20,7 @@ class PrefsWindow(Adw.PreferencesWindow):
   desktop_switch = Gtk.Template.Child()
   history_switch = Gtk.Template.Child()
   clear_history_button = Gtk.Template.Child()
+  data_switch = Gtk.Template.Child()
   clear_data_button = Gtk.Template.Child()
 
   # Connect signals and bindings
@@ -30,6 +31,7 @@ class PrefsWindow(Adw.PreferencesWindow):
     settings.bind('on-start-load', self.start_combo, 'selected', Gio.SettingsBindFlags.DEFAULT)
     settings.bind('search-desktop', self.desktop_switch, 'active', Gio.SettingsBindFlags.DEFAULT)
     settings.bind('keep-history', self.history_switch, 'active', Gio.SettingsBindFlags.DEFAULT)
+    settings.bind('clear-data-on-close', self.data_switch, 'active', Gio.SettingsBindFlags.DEFAULT)
 
     self.clear_history_button.connect('clicked', self._clear_history_button_cb)
     self.clear_data_button.connect('clicked', self._clear_data_button_cb)


### PR DESCRIPTION
Closes #115, Closes #114

Added a toggle to the personal data row in the preferences dialog to add the option to clear cache and cookies when the application is closed. Let me know if you would prefer a different UI.

Screenshot:
![Screenshot](https://github.com/hugolabe/Wike/assets/106203063/5301073c-d7bd-4fd6-81f5-32d323ed67de)
