### PR TITLE
appdata: add vcs-browser support

### DIFF
--- a/data/com.github.hugolabe.Wike.metainfo.xml.in
+++ b/data/com.github.hugolabe.Wike.metainfo.xml.in
@@ -364,6 +364,8 @@
 
   <url type="homepage">https://hugolabe.github.io/Wike/</url>
   <url type="bugtracker">https://github.com/hugolabe/Wike/issues</url>
+  <url type="contribute">https://hugolabe.github.io/Wike/#foss</url>
+  <url type="vcs-browser">https://github.com/hugolabe/Wike</url>
   <url type="translate">https://poeditor.com/join/project?hash=kNgJu4MAum</url>
   <developer_name>Hugo Olabera</developer_name>
   <update_contact>hugolabe@gmail.com</update_contact>


### PR DESCRIPTION
These URL is visible on Flathub and GNOME Control Center.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url