### PR TITLE
Add a 'Restore window' option

### DIFF
--- a/build-aux/flatpak/com.github.hugolabe.Wike.json
+++ b/build-aux/flatpak/com.github.hugolabe.Wike.json
@@ -14,7 +14,6 @@
     "--filesystem=home"
   ],
   "modules" : [
-    "python3-dbus-python.json",
     "python3-requests.json",
     {
       "name" : "wike",

--- a/build-aux/flatpak/com.github.hugolabe.Wike.json
+++ b/build-aux/flatpak/com.github.hugolabe.Wike.json
@@ -14,6 +14,7 @@
     "--filesystem=home"
   ],
   "modules" : [
+    "python3-dbus-python.json",
     "python3-requests.json",
     {
       "name" : "wike",

--- a/data/com.github.hugolabe.Wike.gschema.xml
+++ b/data/com.github.hugolabe.Wike.gschema.xml
@@ -29,7 +29,7 @@
 
     <key name="on-start-load" type="i">
       <default>0</default>
-      <summary>On start load this page (0-Main, 1-Random, 2-Last article, 3-Restore window)</summary>
+      <summary>On start load this page (0-Main, 1-Random, 2-Last article, 3-Restore all tabs)</summary>
     </key>
 
     <key name="last-uri" type="s">

--- a/data/com.github.hugolabe.Wike.gschema.xml
+++ b/data/com.github.hugolabe.Wike.gschema.xml
@@ -29,12 +29,17 @@
 
     <key name="on-start-load" type="i">
       <default>0</default>
-      <summary>On start load this page (0-Main, 1-Random, 2-Last)</summary>
+      <summary>On start load this page (0-Main, 1-Random, 2-Last article, 3-Restore window)</summary>
     </key>
 
     <key name="last-uri" type="s">
       <default>""</default>
       <summary>Last Wikipedia uri loaded</summary>
+    </key>
+
+    <key name="last-window" type="as">
+      <default>[]</default>
+      <summary>Last Wikipedia pages</summary>
     </key>
 
     <key name="theme" type="i">

--- a/data/com.github.hugolabe.Wike.gschema.xml
+++ b/data/com.github.hugolabe.Wike.gschema.xml
@@ -37,9 +37,9 @@
       <summary>Last Wikipedia uri loaded</summary>
     </key>
 
-    <key name="last-window" type="as">
+    <key name="last-window" type="a(ss)">
       <default>[]</default>
-      <summary>Last Wikipedia pages</summary>
+      <summary>Last Wikipedia window uri and title, one for each page</summary>
     </key>
 
     <key name="theme" type="i">

--- a/data/ui/prefs.ui
+++ b/data/ui/prefs.ui
@@ -26,6 +26,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
                       <item translatable="yes">Wikipedia main page</item>
                       <item translatable="yes">Random article</item>
                       <item translatable="yes">Last article</item>
+                      <item translatable="yes">Restore window</item>
                     </items>
                   </object>
                 </property>

--- a/data/ui/prefs.ui
+++ b/data/ui/prefs.ui
@@ -26,7 +26,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
                       <item translatable="yes">Wikipedia main page</item>
                       <item translatable="yes">Random article</item>
                       <item translatable="yes">Last article</item>
-                      <item translatable="yes">Restore window</item>
+                      <item translatable="yes">Restore all tabs</item>
                     </items>
                   </object>
                 </property>

--- a/src/application.py
+++ b/src/application.py
@@ -189,9 +189,9 @@ class Application(Adw.Application):
         tabpage = self._window.tabview.get_nth_page(i_page)
         page = tabpage.get_child()
         if page._lazy_load:
-            pages_data.append(page._lazy_load)
+          pages_data.append(page._lazy_load)
         else:
-            pages_data.append([page.wikiview.get_base_uri(), tabpage.get_title()])
+          pages_data.append([page.wikiview.get_base_uri(), tabpage.get_title()])
       settings.set_value('last-window', GLib.Variant("a(ss)", pages_data))
 
     if not settings.get_boolean('keep-history'):

--- a/src/application.py
+++ b/src/application.py
@@ -184,11 +184,15 @@ class Application(Adw.Application):
       settings.set_string('last-uri', '')
     else:
       settings.set_string('last-uri', self._window.page.wikiview.get_base_uri())
-      pages_uri = []
+      pages_data = []
       for i_page in range(self._window.tabview.get_n_pages()):
-        page = self._window.tabview.get_nth_page(i_page).get_child()
-        pages_uri.append(page.wikiview.get_base_uri())
-      settings.set_strv('last-window', pages_uri)
+        tabpage = self._window.tabview.get_nth_page(i_page)
+        page = tabpage.get_child()
+        if page._lazy_load:
+            pages_data.append(page._lazy_load)
+        else:
+            pages_data.append([page.wikiview.get_base_uri(), tabpage.get_title()])
+      settings.set_value('last-window', GLib.Variant("a(ss)", pages_data))
 
     if not settings.get_boolean('keep-history'):
       history.clear()

--- a/src/application.py
+++ b/src/application.py
@@ -184,6 +184,11 @@ class Application(Adw.Application):
       settings.set_string('last-uri', '')
     else:
       settings.set_string('last-uri', self._window.page.wikiview.get_base_uri())
+      pages_uri = []
+      for i_page in range(self._window.tabview.get_n_pages()):
+        page = self._window.tabview.get_nth_page(i_page).get_child()
+        pages_uri.append(page.wikiview.get_base_uri())
+      settings.set_strv('last-window', pages_uri)
 
     if not settings.get_boolean('keep-history'):
       history.clear()

--- a/src/page.py
+++ b/src/page.py
@@ -8,9 +8,6 @@ from gi.repository import Gtk, WebKit
 from wike.data import settings
 from wike.view import WikiView
 
-LAZY_LOAD_INTERVAL = 500
-LAZY_LOAD_MAX = 7
-
 # Page box for each tab with webview and search bar
 
 @Gtk.Template(resource_path='/com/github/hugolabe/Wike/ui/page.ui')

--- a/src/page.py
+++ b/src/page.py
@@ -9,7 +9,7 @@ from wike.data import settings
 from wike.view import WikiView
 
 LAZY_LOAD_INTERVAL = 500
-LAZY_LOAD_MAX = 15
+LAZY_LOAD_MAX = 7
 
 # Page box for each tab with webview and search bar
 

--- a/src/page.py
+++ b/src/page.py
@@ -120,6 +120,7 @@ class PageBox(Gtk.Box):
       self._window.refresh_menu_actions(wikiview.is_local())
 
     elif event == WebKit.LoadEvent.FINISHED:
+      self._did_lazy_load = False
       tabpage.set_loading(False)
       if wikiview.is_local():
         self._show_status_page(wikiview.get_uri())

--- a/src/page.py
+++ b/src/page.py
@@ -33,7 +33,6 @@ class PageBox(Gtk.Box):
     self._window = window
     self._lazy_load = lazy_load
     self._did_lazy_load = False
-    self._glib_source = -1
 
     self.wikiview = WikiView()
     self.wikiview.set_vexpand(True)
@@ -201,3 +200,4 @@ class PageBox(Gtk.Box):
     tabpage = self._window.tabview.get_page(self)
     if tabpage.get_selected():
       self._window.refresh_nav_actions(self.wikiview)
+

--- a/src/page.py
+++ b/src/page.py
@@ -3,11 +3,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-from gi.repository import Gtk, WebKit
+from gi.repository import Gtk, WebKit, GLib
 
 from wike.data import settings
 from wike.view import WikiView
 
+LAZY_LOAD_INTERVAL = 500
+LAZY_LOAD_MAX = 15
 
 # Page box for each tab with webview and search bar
 
@@ -28,10 +30,13 @@ class PageBox(Gtk.Box):
 
   # Add wikiview, initialize find controller and connect signals
 
-  def __init__(self, window):
+  def __init__(self, window, lazy_load=False):
     super().__init__()
 
     self._window = window
+    self._lazy_load = lazy_load
+    self._did_lazy_load = False
+    self._glib_source = -1
 
     self.wikiview = WikiView()
     self.wikiview.set_vexpand(True)
@@ -54,6 +59,36 @@ class PageBox(Gtk.Box):
     find_controller.connect('failed-to-find-text', self._find_controller_not_found_cb)
     nav_list.connect('changed', self._nav_list_changed_cb)
 
+  # Start a timer to load the page later
+
+  def begin_lazy_load(self, pool):
+    if not self._lazy_load:
+      return
+    timeout = LAZY_LOAD_INTERVAL * (pool.index(self) + 1)
+    def _load_page_now():
+        self.load_page_now(pool)
+        return False
+
+    if pool.index(self) < LAZY_LOAD_MAX:
+        self._glib_source = GLib.timeout_add(timeout, _load_page_now)
+
+  # On the end of timer, or when the user selects the page, load it
+
+  def load_page_now(self, pool):
+    uri, title = self._lazy_load
+    pool.remove(self)
+    if self._glib_source >= 0:
+      GLib.Source.remove(self._glib_source)
+      self._glib_source = -1
+
+    if uri == 'blank' or uri == 'notfound':
+      self.wikiview.load_message(uri)
+    else:
+      self.wikiview.load_wiki(uri)
+
+    self._lazy_load = False
+    self._did_lazy_load = True
+
   # Manage wikiview load page events
 
   def _wikiview_load_changed_cb(self, wikiview, event):
@@ -67,8 +102,10 @@ class PageBox(Gtk.Box):
       if self.search_bar.get_search_mode():
         self.search_bar.set_search_mode(False)
       self.view_stack.set_visible_child_name('wikiview')
-      tabpage.set_title(_('Loading'))
-      tabpage.set_loading(True)
+      if self._lazy_load or not self._did_lazy_load:
+        tabpage.set_title(_('Loading'))
+        tabpage.set_loading(True)
+        self._did_lazy_load = False
       if tabpage.get_selected():
         self._window.headerbar.search_box.reset()
         wikiview.grab_focus()

--- a/src/window.py
+++ b/src/window.py
@@ -111,11 +111,17 @@ class Window(Adw.ApplicationWindow):
           self.page.wikiview.load_main()
         elif settings.get_int('on-start-load') == 1:
           self.page.wikiview.load_random()
-        else:
+        elif settings.get_int('on-start-load') == 2:
           if settings.get_string('last-uri'):
             self.page.wikiview.load_wiki(settings.get_string('last-uri'))
           else:
             self.page.wikiview.load_main()
+        elif len(settings.get_strv('last-window')) == 0:
+            self.page.wikiview.load_main()
+        else:
+          for i, uri in enumerate(settings.get_strv('last-window')):
+            if i==0: self.page.wikiview.load_wiki(uri)
+            else: self.new_page(uri, None, uri == settings.get_string('last-uri'))
 
   # Set actions for window
   

--- a/src/window.py
+++ b/src/window.py
@@ -56,6 +56,7 @@ class Window(Adw.ApplicationWindow):
 
     self.page = PageBox(self)
     tabpage = self.tabview.append(self.page)
+    tabpage.set_live_thumbnail(True)
 
     self.actionbar = ActionBar()
     self.window_box.append(self.actionbar)
@@ -288,6 +289,8 @@ class Window(Adw.ApplicationWindow):
     self.page = tabpage.get_child()
     if self.page._lazy_load:
       self.page.load_page_now(self._pool)
+    if self.page.wikiview.is_loading():
+      tabpage.set_loading(True)
     self.refresh_nav_actions(self.page.wikiview)
     self.refresh_menu_actions(self.page.wikiview.is_local())
     self.toc_box.populate(self.page.wikiview.title, self.page.wikiview.sections)


### PR DESCRIPTION
This would fix #100.

The app is a little bit laggy for me during the first seconds when opening several pages, but nothing too bad; and I guess the trade-off is worth it! I tried to add the pages via `GLib.idle_add` too to see if it would increase performances, but it does not.

It also switches to the latest opened tab when opening them, so it effectively restores the last session nearly entirely.