### PR TITLE
appdata: Remove Purism metadata

### DIFF
--- a/data/com.github.hugolabe.Wike.metainfo.xml.in
+++ b/data/com.github.hugolabe.Wike.metainfo.xml.in
@@ -357,11 +357,6 @@
     </release>
   </releases>
 
-  <custom>
-    <value key="Purism::form_factor">workstation</value>
-    <value key="Purism::form_factor">mobile</value>
-  </custom>
-
   <url type="homepage">https://hugolabe.github.io/Wike/</url>
   <url type="bugtracker">https://github.com/hugolabe/Wike/issues</url>
   <url type="contribute">https://hugolabe.github.io/Wike/#foss</url>


### PR DESCRIPTION
This metadata is invalid: custom data is a dictionary and using the same key multiple times in a dictionary does not work

More information: https://github.com/ximion/appstream/issues/476