### PR TITLE
Add a remove button for history row

### DIFF
--- a/data/ui/history-row.ui
+++ b/data/ui/history-row.ui
@@ -9,34 +9,51 @@ SPDX-License-Identifier: GPL-3.0-or-later
   <template class="HistoryRow" parent="GtkListBoxRow">
     <child>
       <object class="GtkBox">
-        <property name="orientation">vertical</property>
         <property name="margin-top">6</property>
         <property name="margin-bottom">6</property>
         <property name="margin-start">3</property>
-        <property name="margin-end">3</property>
-        <property name="spacing">3</property>
-        <child>
-          <object class="GtkLabel" id="title_label">
-            <property name="halign">start</property>
-            <property name="ellipsize">end</property>
-          </object>
-        </child>
+        <property name="spacing">12</property>
         <child>
           <object class="GtkBox">
-            <property name="spacing">6</property>
+            <property name="orientation">vertical</property>
+            <property name="hexpand">true</property>
+            <property name="valign">center</property>
+            <property name="spacing">3</property>
             <child>
-              <object class="GtkLabel" id="time_label">
+              <object class="GtkLabel" id="title_label">
                 <property name="halign">start</property>
-                <property name="use-markup">true</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkLabel" id="lang_label">
-                <property name="halign">start</property>
-                <property name="use-markup">true</property>
                 <property name="ellipsize">end</property>
               </object>
             </child>
+            <child>
+              <object class="GtkBox">
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkLabel" id="time_label">
+                    <property name="halign">start</property>
+                    <property name="use-markup">true</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lang_label">
+                    <property name="halign">start</property>
+                    <property name="use-markup">true</property>
+                    <property name="ellipsize">end</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="remove_button">
+            <property name="icon-name">window-close-symbolic</property>
+            <property name="valign">center</property>
+            <style>
+              <class name="flat"/>
+              <class name="circular"/>
+              <class name="bookmarks-remove"/>
+            </style>
           </object>
         </child>
       </object>

--- a/src/data.py
+++ b/src/data.py
@@ -85,6 +85,19 @@ class History:
       self.items[date][uri] = [time, title, lang]
     else:
       self.items[date] = {uri: [time, title, lang]}
+    return date, time
+
+  # Remove item from history list
+
+  def remove(self, date, time, uri):
+    if date in self.items:
+      if uri in self.items[date]:
+        del self.items[date][uri]
+      if len(self.items[date]) == 0:
+        del self.items[date]
+      return True
+    else:
+      return False
 
   # Clear history
 

--- a/src/history.py
+++ b/src/history.py
@@ -46,6 +46,9 @@ class HistoryBox(Gtk.Box):
     settings.connect('changed::keep-history', self._keep_history_changed_cb)
     settings.connect('changed::filter-history', self._filter_history_changed_cb)
 
+    self._date_labels = {}
+    self._history_rows = {}
+
     self._populate()
 
     self.clear_button.connect('clicked', self._clear_button_cb)
@@ -82,24 +85,19 @@ class HistoryBox(Gtk.Box):
       if days >= filter_days:
         break
 
-      date_label = Gtk.Label()
-      date_label.set_markup('<b>' + date + '</b>')
-      date_label.set_xalign(0)
-      date_label.set_margin_start(3)
-      date_label.set_margin_end(3)
-      row = Gtk.ListBoxRow()
-      row.set_child(date_label)
-      row.set_activatable(False)
-      row.set_selectable(False)
-      self.history_list.append(row)
+      date_row = self._new_date_label(date)
+      self._date_labels[date] = date_row
+      self.history_list.append(date_row)
 
       history_item = history.items[date]
       for uri in sorted(history_item, key=history_item.get, reverse=True):
         time = history_item[uri][0]
         title = history_item[uri][1]
         lang = history_item[uri][2]
-        row = HistoryRow(uri, title, lang, time)
+        row = HistoryRow(uri, title, lang, date, time)
         self.history_list.append(row)
+        self._history_rows[(date, uri)] = row
+        row.remove_button.connect('clicked', self._row_remove_button_cb, row)
 
   # Clear history list
 
@@ -114,14 +112,50 @@ class HistoryBox(Gtk.Box):
   # Add article to history
 
   def add_item(self, uri, title, lang):
-    history.add(uri, title, lang)
-    self._populate()
+    date, time = history.add(uri, title, lang)
+    if (date, uri) in self._history_rows:
+      self._row_remove_button_cb(None, self._history_rows[(date, uri)])
+    row = HistoryRow(uri, title, lang, date, time)
+    if date in self._date_labels:
+      date_row = self._date_labels[date]
+      self.history_list.remove(date_row)
+    else:
+      date_row = self._new_date_label(date)
+    self.history_list.prepend(row)
+    self.history_list.prepend(date_row)
+    self._history_rows[(date, uri)] = row
+    row.remove_button.connect('clicked', self._row_remove_button_cb, row)
+
+  def _new_date_label(self, date):
+    date_label = Gtk.Label()
+    date_label.set_markup('<b>' + date + '</b>')
+    date_label.set_xalign(0)
+    date_label.set_margin_start(3)
+    date_label.set_margin_end(3)
+    date_row = Gtk.ListBoxRow()
+    date_row.set_child(date_label)
+    date_row.set_activatable(False)
+    date_row.set_selectable(False)
+    self._date_labels[date] = date_row
+    return date_row
+
+  # On row button remove history row and refresh buttons state
+
+  def _row_remove_button_cb(self, remove_button, row):
+    if history.remove(row.date, row.time, row.uri):
+      self.history_list.remove(row)
+      if row.date not in [key[0] for key in self._history_rows]:
+        self.history_list.remove(self._date_labels[row.date])
+        del self._date_labels[row.date]
+      del self._history_rows[(row.date, row.uri)]
 
   # Clear history of recent articles
 
   def clear_history(self):
     history.clear()
     history.save()
+    self._history_rows.clear()
+    self._date_labels.clear()
     self._clear_list()
 
   # Settings keep history changed event
@@ -208,16 +242,18 @@ class HistoryRow(Gtk.ListBoxRow):
   title_label = Gtk.Template.Child()
   lang_label = Gtk.Template.Child()
   time_label = Gtk.Template.Child()
+  remove_button = Gtk.Template.Child()
 
   # Set values and widgets
 
-  def __init__(self, uri, title, lang, time):
+  def __init__(self, uri, title, lang, date, time):
     super().__init__()
 
     self.uri = uri
     self.title = title
     self.lang = lang
-    self.time = time.rsplit(':', 1)[0]
+    self.date = date
+    self.time = time
 
     if lang in languages.wikilangs:
       lang_name = languages.wikilangs[lang].capitalize()
@@ -226,4 +262,4 @@ class HistoryRow(Gtk.ListBoxRow):
 
     self.title_label.set_label(title)
     self.lang_label.set_markup('<small>' + lang_name + '</small>')
-    self.time_label.set_markup('<small>' + self.time + '</small>')
+    self.time_label.set_markup('<small>' + self.time.rsplit(':', 1)[0] + '</small>')

--- a/src/history.py
+++ b/src/history.py
@@ -144,10 +144,10 @@ class HistoryBox(Gtk.Box):
   def _row_remove_button_cb(self, remove_button, row):
     if history.remove(row.date, row.time, row.uri):
       self.history_list.remove(row)
+      del self._history_rows[(row.date, row.uri)]
       if row.date not in [key[0] for key in self._history_rows]:
         self.history_list.remove(self._date_labels[row.date])
         del self._date_labels[row.date]
-      del self._history_rows[(row.date, row.uri)]
 
   # Clear history of recent articles
 


### PR DESCRIPTION
This fixes #101.

I was heavily inspired by your implementation of bookmark remove buttons, however the implementation is a little bit different because of the way the history needs to allow uri duplicates, etc

It seems to work all right for me, maybe some additional testing would be better though (as I may have not though about all the edge cases).

By the way, sorry for my urge to make pull requests for your app, I just love using it and wanted to give it a little bit back!