### PR TITLE
Appdata related patches

### DIFF
--- a/data/com.github.hugolabe.Wike.metainfo.xml.in
+++ b/data/com.github.hugolabe.Wike.metainfo.xml.in
@@ -21,6 +21,16 @@
     </p>
   </description>
 
+  <categories>
+      <category>Network</category>
+      <category>GTK</category>
+  </categories>
+
+  <keywords>
+    <keyword translate="no">Wikipedia</keyword>
+    <keyword>Encyclopedia</keyword>
+  </keywords>
+
   <launchable type="desktop-id">com.github.hugolabe.Wike.desktop</launchable>
   <translation type="gettext">wike</translation>
   <content_rating type="oars-1.1" />

--- a/data/meson.build
+++ b/data/meson.build
@@ -30,10 +30,10 @@ appstream_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util,
-    args: ['validate', appstream_file]
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('Validate appstream file', appstreamcli,
+    args: ['validate', '--no-net', appstream_file]
   )
 endif
 


### PR DESCRIPTION
### appdata: use appstreamcli for appdata validation

appstream-util is obsoleted by appstreamcli.

### data: Update appdata

Add categories and keywords.

Entries are copied from the desktop file.
