### PR TITLE
CI: Bumped Checkout (v4), Flatpak Builder (v6.3) & Setup Qemu Action (v3)

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -15,17 +15,17 @@ jobs:
         arch: [x86_64, aarch64]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     # Docker is required by the docker/setup-qemu-action which enables emulation
     - name: Install deps
       run: |
         dnf -y install docker
     - name: Set up QEMU
       id: qemu
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: arm64
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.1
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.3
       with:
         bundle: com.github.hugolabe.Wike.flatpak
         manifest-path: build-aux/flatpak/com.github.hugolabe.Wike.json


### PR DESCRIPTION
### Details

- Bump `actions/checkout` from `v3` to `v4` the changes can be found [here](https://github.com/actions/checkout/compare/v3...v4), this includes **Node 20**
- Bump `docker/setup-qemu-action` from `v2` to `v3`, changes can be found [here](https://github.com/docker/setup-qemu-action/compare/v2.2.0...v3.0.0)
-  Bump `bilelmoussaoui/flatpak-github-actions/flatpak-builder` from `v6.1` to `v6.3`
