### PR TITLE
add support for [lang]:[search term] format to in-app and shell search

### DIFF
--- a/src/search.py
+++ b/src/search.py
@@ -102,6 +102,10 @@ class SearchBox(Gtk.Box):
         text = terms[1]
       else:
         text = ''
+    elif ':' in text:
+      for available_lang in languages.wikilangs.keys():
+        if text.startswith(available_lang + ':'):
+          lang, text = text.split(':', 1)
     return text, lang
 
   # When search stoped with ESC hide suggestions

--- a/src/wike-sp.in
+++ b/src/wike-sp.in
@@ -83,6 +83,10 @@ class WikeSearchService:
         text = text.split(' ', 1)[1]
       else:
         text = ''
+    elif ':' in text:
+      for available_lang in languages.wikilangs.keys():
+        if text.startswith(available_lang + ':'):
+          lang, text = text.split(':', 1)
 
     if len(text) > 2:
       if settings.get_boolean('search-desktop'):


### PR DESCRIPTION
The format [lang]:[page name] is the common and widely known format for interwiki links, and thus makes sense to support as a format for the search for a deviation from the default language.