### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/build-aux/flatpak/com.github.hugolabe.Wike.json
+++ b/build-aux/flatpak/com.github.hugolabe.Wike.json
@@ -19,6 +19,7 @@
       "name" : "wike",
       "buildsystem" : "meson",
       "builddir" : true,
+      "run-tests" : true,
       "sources" : [
         {
           "type" : "dir",

--- a/data/com.github.hugolabe.Wike.metainfo.xml.in
+++ b/data/com.github.hugolabe.Wike.metainfo.xml.in
@@ -21,16 +21,6 @@
     </p>
   </description>
 
-  <categories>
-      <category>Network</category>
-      <category>GTK</category>
-  </categories>
-
-  <keywords>
-    <keyword translate="no">Wikipedia</keyword>
-    <keyword>Encyclopedia</keyword>
-  </keywords>
-
   <launchable type="desktop-id">com.github.hugolabe.Wike.desktop</launchable>
   <translation type="gettext">wike</translation>
   <content_rating type="oars-1.1" />
@@ -387,6 +377,10 @@
   <url type="contribute">https://hugolabe.github.io/Wike/#foss</url>
   <url type="vcs-browser">https://github.com/hugolabe/Wike</url>
   <url type="translate">https://poeditor.com/join/project?hash=kNgJu4MAum</url>
-  <developer_name>Hugo Olabera</developer_name>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
+  <developer_name translatable="no">Hugo Olabera</developer_name>
+  <developer id="github.com">
+      <name translatable="no">Hugo Olabera</name>
+  </developer>
   <update_contact>hugolabe@gmail.com</update_contact>
 </component>

--- a/data/meson.build
+++ b/data/meson.build
@@ -32,8 +32,10 @@ appstream_file = i18n.merge_file(
 
 appstreamcli = find_program('appstreamcli', required: false)
 if appstreamcli.found()
-  test('Validate appstream file', appstreamcli,
-    args: ['validate', '--no-net', appstream_file]
+  test('Validate appstream file',
+    appstreamcli,
+    args: ['validate', '--no-net', '--explain', appstream_file],
+    workdir: meson.current_build_dir()
   )
 endif
 


### PR DESCRIPTION
- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Mark the developer_name as untranslatable
- Improve appstreamcli parameters
- Activate meson tests on flatpak manifest

### Appdata: Fix my mistake

"Icons and categories

If there’s a type="desktop-id" launchable, they get pulled from it. Most of the icon not found errors with the flathub builder can be traced down to the launchable value not matching the desktop file name.

Don’t set them in the AppData unless you want to override them (even though then it might be a better idea to patch the desktop file itself)."

More information: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#icons-and-categories