### PR TITLE
add ability to display window controls in every toolbar view

### DIFF
--- a/data/gtk/bookmarks.ui
+++ b/data/gtk/bookmarks.ui
@@ -13,34 +13,34 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
         <!-- Header -->
         <child type="top">
-          <object class="GtkBox">
-            <style>
-              <class name="toolbar"/>
-            </style>
+          <object class="AdwHeaderBar">
+            <property name="title-widget">
+              <object class="GtkBox">
+                <!-- Bookmark list selector -->
+                <child>
+                  <object class="GtkDropDown" id="booklists_dropdown">
+                    <property name="hexpand">true</property>
+                  </object>
+                </child>
 
-            <!-- Bookmark list selector -->
-            <child>
-              <object class="GtkDropDown" id="booklists_dropdown">
-                <property name="hexpand">true</property>
+                <!-- Add bookmark button -->
+                <child>
+                  <object class="GtkButton" id="add_button">
+                    <property name="icon-name">bookmark-new-symbolic</property>
+                    <property name="tooltip-text" translatable="yes">Add Bookmark</property>
+                    <property name="action-name">win.add-bookmark</property>
+                  </object>
+                </child>
+
+                <!-- Menu button -->
+                <child>
+                  <object class="GtkMenuButton" id="menu_button">
+                    <property name="icon-name">view-more-symbolic</property>
+                  </object>
+                </child>
+
               </object>
-            </child>
-
-            <!-- Add bookmark button -->
-            <child>
-              <object class="GtkButton" id="add_button">
-                <property name="icon-name">bookmark-new-symbolic</property>
-                <property name="tooltip-text" translatable="yes">Add Bookmark</property>
-                <property name="action-name">win.add-bookmark</property>
-              </object>
-            </child>
-
-            <!-- Menu button -->
-            <child>
-              <object class="GtkMenuButton" id="menu_button">
-                <property name="icon-name">view-more-symbolic</property>
-              </object>
-            </child>
-
+            </property>
           </object>
         </child>
 

--- a/data/gtk/langlinks.ui
+++ b/data/gtk/langlinks.ui
@@ -13,19 +13,13 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
         <!-- Header -->
         <child type="top">
-          <object class="GtkBox">
-            <style>
-              <class name="toolbar"/>
-            </style>
-
-            <!-- Filter entry -->
-            <child>
+          <object class="AdwHeaderBar">
+            <property name="title-widget">
               <object class="GtkSearchEntry" id="filter_entry">
                 <property name="placeholder-text" translatable="yes">Filter languages</property>
                 <property name="hexpand">true</property>
               </object>
-            </child>
-
+            </property>
           </object>
         </child>
 

--- a/data/gtk/style.css
+++ b/data/gtk/style.css
@@ -76,3 +76,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
   color: @destructive_fg_color;
   background-color: @destructive_color;
 }
+
+windowcontrols.floating-window-controls.empty {
+  margin: 0;
+}

--- a/data/gtk/toc.ui
+++ b/data/gtk/toc.ui
@@ -13,17 +13,20 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
         <!-- Article title label -->
         <child type="top">
-          <object class="GtkLabel" id="title_label">
-            <property name="margin-start">15</property>
-            <property name="margin-end">15</property>
-            <property name="height-request">46</property>
-            <property name="xalign">0</property>
-            <property name="width-chars">30</property>
-            <property name="max-width-chars">30</property>
-            <property name="ellipsize">end</property>
-            <style>
-              <class name="heading"/>
-            </style>
+          <object class="AdwHeaderBar">
+            <property name="title-widget">
+              <object class="GtkLabel" id="title_label">
+                <property name="margin-start">15</property>
+                <property name="margin-end">15</property>
+                <property name="xalign">0</property>
+                <property name="width-chars">30</property>
+                <property name="max-width-chars">30</property>
+                <property name="ellipsize">end</property>
+                <style>
+                  <class name="heading"/>
+                </style>
+              </object>
+            </property>
           </object>
         </child>
 

--- a/data/gtk/window.ui
+++ b/data/gtk/window.ui
@@ -51,10 +51,26 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
                 <!-- LEFT BAR -->
                 <property name="sidebar">
-                  <object class="AdwToolbarView">
+                  <object class="GtkBox">
+
+                    <property name="orientation">vertical</property>
+
+                    <child>
+                      <object class="GtkWindowControls">
+                        <property name="halign">center</property>
+                        <property name="side">start</property>
+                        <property name="margin-top">6</property>
+                        <property name="margin-bottom">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="margin-end">6</property>
+                        <style>
+                          <class name="floating-window-controls"/>
+                        </style>
+                      </object>
+                    </child>
 
                     <!-- LEFT BAR: Main menu button -->
-                    <child type="top">
+                    <child>
                       <object class="GtkMenuButton" id="main_button">
                         <property name="icon-name">open-menu-symbolic</property>
                         <property name="tooltip-text" translatable="yes">Main Menu</property>
@@ -70,7 +86,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
                     </child>
 
                     <!-- LEFT BAR: Selector buttons box -->
-                    <property name="content">
+                    <child>
                       <object class="GtkBox">
                         <property name="orientation">vertical</property>
                         <property name="vexpand">true</property>
@@ -131,10 +147,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
                         </child>
 
                       </object>
-                    </property>
+                    </child>
 
                     <!-- LEFT BAR: Sidebar button -->
-                    <child type="bottom">
+                    <child>
                       <object class="GtkToggleButton" id="panel_button">
                         <property name="icon-name">sidebar-show-symbolic</property>
                         <property name="tooltip-text" translatable="yes">Sidebar</property>


### PR DESCRIPTION
Using Adw.HeaderBar as the top child of an Adw.ToolbarView ensures that window controls are always displayed correctly. This is an issue for the small window sizes (<= 450px width), where the sidebar does not display them. This is, however, the normal behaviour for those kinds of sidebars covering the whole app's primary window.

Additionally, the left most pane visible in medium and large window mode (<= 750px and 751px+) would need manually added Gtk.WindowControls for side: start to supported close buttons on the left for completeness purposes.

(You cannot close Wike in medium and large window mode if the button layout is "close:", i.e. the close button is on the left.)