### PR TITLE
use correct developer ID in AppStream meta data

### DIFF
--- a/data/com.github.hugolabe.Wike.metainfo.xml.in
+++ b/data/com.github.hugolabe.Wike.metainfo.xml.in
@@ -384,7 +384,7 @@
   <url type="translate">https://poeditor.com/join/project?hash=kNgJu4MAum</url>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Hugo Olabera</developer_name>
-  <developer id="github.com">
+  <developer id="io.github.hugolabe">
     <name translatable="no">Hugo Olabera</name>
   </developer>
   <update_contact>hugolabe@gmail.com</update_contact>


### PR DESCRIPTION
The ID "github.com" does not uniquely identify you, Hugo Olabera, as a developer. As such, it is not a correct one.

Furthermore, the documentation for AppStream was updated to clarify how the id is supposed to look, and recommends the use of reverse-DNS, or of ActivityPub handles.

Link: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer