### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/com.github.hugolabe.Wike.metainfo.xml.in
+++ b/data/com.github.hugolabe.Wike.metainfo.xml.in
@@ -50,7 +50,7 @@
 
   <releases>
     <release version="3.0.1" date="2024-03-23">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Updated translations: French, Italian.</li>
           <li>Fixes.</li>
@@ -58,7 +58,7 @@
       </description>
     </release>
     <release version="3.0.0" date="2024-03-08">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Revamped UI to fit new libadwaita design styles.</li>
           <li>Side panel redesign that is now located on the left.</li>
@@ -77,7 +77,7 @@
       </description>
     </release>
     <release version="2.1.0" date="2023-12-04">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added an option to clear personal data on exit.</li>
           <li>Added an option to restore open articles on start.</li>
@@ -92,7 +92,7 @@
       </description>
     </release>
     <release version="2.0.1" date="2023-04-23">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Bug fixes.</li>
           <li>Small UI tweaks.</li>
@@ -101,7 +101,7 @@
       </description>
     </release>
     <release version="2.0.0" date="2023-04-12">
-      <description translatable="no">
+      <description translate="no">
         <p>This version brings a major revamp to the user interface and also introduces some new features. These are the main novelties:</p>
         <ul>
           <li>Migration to GTK4 + Libadwaita.</li>
@@ -121,7 +121,7 @@
       </description>
     </release>
     <release version="1.8.3" date="2023-03-03">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added shortcut for Random Article.</li>
           <li>Small UI tweaks.</li>
@@ -131,7 +131,7 @@
       </description>
     </release>
     <release version="1.8.2" date="2022-10-24">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Bulgarian translation.</li>
           <li>Updated Turkish translation.</li>
@@ -140,7 +140,7 @@
       </description>
     </release>
     <release version="1.8.1" date="2022-09-07">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Tamil translation.</li>
           <li>Updated Dutch translation.</li>
@@ -148,7 +148,7 @@
       </description>
     </release>
     <release version="1.8.0" date="2022-05-28">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>System light/dark theme support.</li>
           <li>Updated Wikipedia language list.</li>
@@ -159,7 +159,7 @@
       </description>
     </release>
     <release version="1.7.2" date="2022-03-31">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Flatpak runtime bumped to GNOME 42.</li>
           <li>Updated translations: Turkish.</li>
@@ -167,7 +167,7 @@
       </description>
     </release>
     <release version="1.7.1" date="2022-02-06">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added translations: Bengali, Chinese (traditional).</li>
           <li>Updated translations: Catalan, French.</li>
@@ -175,7 +175,7 @@
       </description>
     </release>
     <release version="1.7.0" date="2022-01-19">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Desktop searches in multiple languages.</li>
           <li>Context menu improvements.</li>
@@ -184,7 +184,7 @@
       </description>
     </release>
     <release version="1.6.3" date="2021-12-10">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Basque translation.</li>
           <li>Updated Persian translation.</li>
@@ -192,7 +192,7 @@
       </description>
     </release>
     <release version="1.6.2" date="2021-12-03">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added translations: Catalan.</li>
           <li>Updated translations: German and Japanese.</li>
@@ -201,7 +201,7 @@
       </description>
     </release>
     <release version="1.6.1" date="2021-11-16">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added translations: Japanese, Persian and Polish.</li>
           <li>Updated translations: Interlingua, Italian, Russian and Turkish.</li>
@@ -209,7 +209,7 @@
       </description>
     </release>
     <release version="1.6.0" date="2021-10-15">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Open multiple articles in tabs.</li>
           <li>Added sepia mode.</li>
@@ -220,14 +220,14 @@
       </description>
     </release>
     <release version="1.5.7" date="2021-09-21">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Croatian and Galician translations.</li>
         </ul>
       </description>
     </release>
     <release version="1.5.6" date="2021-09-09">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Updated French and Italian translations.</li>
           <li>Bug fixes.</li>
@@ -235,7 +235,7 @@
       </description>
     </release>
     <release version="1.5.5" date="2021-09-05">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Small UI tweaks.</li>
           <li>Fixed some texts.</li>
@@ -245,7 +245,7 @@
       </description>
     </release>
     <release version="1.5.4" date="2021-08-10">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Fix alignment issues in Historic view.</li>
           <li>Added Indonesian translation.</li>
@@ -253,7 +253,7 @@
       </description>
     </release>
     <release version="1.5.3" date="2021-07-09">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Finnish translation.</li>
           <li>Updated Russian translation.</li>
@@ -261,7 +261,7 @@
       </description>
     </release>
     <release version="1.5.2" date="2021-07-05">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Czech and Russian translations.</li>
           <li>Updated German translation.</li>
@@ -269,7 +269,7 @@
       </description>
     </release>
     <release version="1.5.1" date="2021-06-25">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Improvements in privacy management.</li>
           <li>Updated translations: Dutch, French, Portuguese (BR) and Spanish.</li>
@@ -277,7 +277,7 @@
       </description>
     </release>
     <release version="1.5.0" date="2021-06-18">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>GNOME Shell search integration.</li>
           <li>Added an option in preferences to show preview popups in article links.</li>
@@ -287,7 +287,7 @@
       </description>
     </release>
     <release version="1.4.2" date="2021-06-04">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Interlingua translation.</li>
           <li>Updated German translation.</li>
@@ -298,7 +298,7 @@
       </description>
     </release>
     <release version="1.4.1" date="2021-05-28">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Dutch translation.</li>
           <li>Updated French translation.</li>
@@ -307,7 +307,7 @@
       </description>
     </release>
     <release version="1.4.0" date="2021-05-21">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added dark mode.</li>
           <li>Updated Spanish translation.</li>
@@ -315,7 +315,7 @@
       </description>
     </release>
     <release version="1.3.3" date="2021-05-13">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Greek translation.</li>
           <li>Updated Italian translation.</li>
@@ -323,7 +323,7 @@
       </description>
     </release>
     <release version="1.3.2" date="2021-05-08">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added Ctrl+K shortcut to search articles.</li>
           <li>Increased maximum font size.</li>
@@ -334,7 +334,7 @@
       </description>
     </release>
     <release version="1.3.1" date="2021-05-07">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Article view improvements.</li>
           <li>Updated French translation.</li>
@@ -342,21 +342,21 @@
       </description>
     </release>
     <release version="1.3.0" date="2021-04-28">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added option to use custom font in article view.</li>
         </ul>
       </description>
     </release>
     <release version="1.2.1" date="2021-04-22">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added German translation.</li>
         </ul>
       </description>
     </release>
     <release version="1.2.0" date="2021-04-21">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Correction in French translation.</li>
           <li>Switch to GNOME Platform 40 runtime.</li>
@@ -366,7 +366,7 @@
       </description>
     </release>
     <release version="1.1.1" date="2021-04-14">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added French translation.</li>
           <li>Added Italian translation.</li>
@@ -375,7 +375,7 @@
       </description>
     </release>
     <release version="1.1.0" date="2021-04-12">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Improved text search bar, with prev/next buttons and match counter.</li>
           <li>Correction in spanish translation.</li>
@@ -383,14 +383,14 @@
       </description>
     </release>
     <release version="1.0.2" date="2021-03-24">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Fix content rating missed in metainfo.</li>
         </ul>
       </description>
     </release>
     <release version="1.0.1" date="2021-03-24">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>CSS style tweaks.</li>
           <li>Changes in app distribution files.</li>
@@ -398,7 +398,7 @@
       </description>
     </release>
     <release version="1.0.0" date="2021-03-19">
-      <description translatable="no">
+      <description translate="no">
         <p>Initial release.</p>
       </description>
     </release>
@@ -410,9 +410,9 @@
   <url type="vcs-browser">https://github.com/hugolabe/Wike</url>
   <url type="translate">https://poeditor.com/join/project?hash=kNgJu4MAum</url>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
-  <developer_name translatable="no">Hugo Olabera</developer_name>
+  <developer_name translate="no">Hugo Olabera</developer_name>
   <developer id="io.github.hugolabe">
-    <name translatable="no">Hugo Olabera</name>
+    <name translate="no">Hugo Olabera</name>
   </developer>
   <update_contact>hugolabe@gmail.com</update_contact>
 </component>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html