### PR TITLE
Use gi.require_version('Soup', '3.0')

### DIFF
--- a/src/wikipedia.py
+++ b/src/wikipedia.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-import json, urllib.parse
-
+import json, urllib.parse, gi
+gi.require_version('Soup', '3.0')
 from gi.repository import Soup
 
 


### PR DESCRIPTION
Use gi.require_version('Soup', '3.0') fix's an issue when no soup version is specified.