### PR TITLE
Check if params are exists before processing

### DIFF
--- a/src/wike-sp.in
+++ b/src/wike-sp.in
@@ -115,7 +115,8 @@ class WikeSearchService:
       self._results.clear()
       text = id.replace('search:', '', 1)
       params = text.split(':', 1)
-      self._get_results(params[1], params[0])
+      if (len(params) > 1):
+         self._get_results(params[1], params[0])
       if len(self._results) > 0:
         uri = list(self._results.keys())[0]
       else:


### PR DESCRIPTION
Test case: run the following command:
```
gdbus call -e -d com.github.hugolabe.Wike.SearchProvider -o /com/github/hugolabe/Wike/SearchProvider -m org.gnome.Shell.SearchProvider2.ActivateResult "search:something" "[]" 0
```
which procedures the following error:
```
Traceback (most recent call last):
  File "/usr/share/wike/wike-sp", line 182, in on_dbus_method_call
    results = method(*arguments),
              ~~~~~~^^^^^^^^^^^^
  File "/usr/share/wike/wike-sp", line 118, in ActivateResult
    self._get_results(params[1], params[0])
                      ~~~~~~^^^
IndexError: list index out of range
```