### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/com.github.hugolabe.Wike.desktop.in
+++ b/data/com.github.hugolabe.Wike.desktop.in
@@ -6,6 +6,7 @@ Exec=wike
 Terminal=false
 Type=Application
 StartupNotify=true
+DBusActivatable=true
 Categories=Network;GTK;
 # Translators: Do not translate or localize the semicolons
 Keywords=Wikipedia;Encyclopedia;

--- a/data/com.github.hugolabe.Wike.service.in
+++ b/data/com.github.hugolabe.Wike.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.github.hugolabe.Wike
+Exec=@BIN@ --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -63,6 +63,14 @@ configure_file(
   install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'dbus-1', 'services')
 )
 
+configure_file(
+  input: 'com.github.hugolabe.Wike.service.in',
+  output: 'com.github.hugolabe.Wike.service',
+  configuration: conf,
+  install: true,
+  install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'dbus-1', 'services')
+)
+
 icondir = join_paths(get_option('prefix'), get_option('datadir'), 'icons', 'hicolor')
 install_data('icons/com.github.hugolabe.Wike.svg', install_dir: join_paths(icondir, 'scalable/apps'))
 install_data('icons/com.github.hugolabe.Wike-symbolic.svg', install_dir: join_paths(icondir, 'symbolic/apps'))


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html