### PR TITLE
Added command line searching

### DIFF
--- a/src/application.py
+++ b/src/application.py
@@ -17,6 +17,7 @@ from wike.data import settings, languages, history, bookmarks
 from wike.prefs import PrefsDialog
 from wike.window import Window
 from wike.view import network_session
+from wike import wikipedia
 
 
 # Main application class for Wike
@@ -30,8 +31,10 @@ class Application(Adw.Application):
 
     self._window = None
     self._launch_uri = ''
+    self._search_query = ''
 
     self.add_main_option('url', b'u', GLib.OptionFlags.NONE, GLib.OptionArg.STRING, 'Open Wikipedia URL', None)
+    self.add_main_option('search', b's', GLib.OptionFlags.NONE, GLib.OptionArg.STRING, 'Search Wikipedia', None)
 
   # Load custom css and set actions
 
@@ -95,6 +98,16 @@ class Application(Adw.Application):
       if self._window:
         self._window.new_page(self._launch_uri, None, True)
 
+
+    if 'search' in options:
+      self._search_query = options['search']
+
+      if self._window:
+        launch_uri = wikipedia.search(self._search_query.lower(), 'en', 1, False)[1][0]
+        self._window.new_page(launch_uri, None, True)
+        self._window.search_panel.search_entry.set_text(self._search_query)
+
+    
     self.activate()
     return 0
 
@@ -102,7 +115,7 @@ class Application(Adw.Application):
 
   def do_activate(self):
     if not self._window:
-      self._window = Window(self, self._launch_uri)
+      self._window = Window(self, self._launch_uri, self._search_query)
       self._window.connect('close-request',self._window_close_cb)
 
     self._window.present()

--- a/src/window.py
+++ b/src/window.py
@@ -15,6 +15,7 @@ from wike.menu import ArticleMenuPopover, MainMenuPopover, ViewMenuPopover
 from wike.page import PageBox
 from wike.search import SearchPanel
 from wike.toc import TocPanel
+from wike import wikipedia
 
 
 # Main window
@@ -53,7 +54,7 @@ class Window(Adw.ApplicationWindow):
 
   # Initialize window, set actions and connect signals
 
-  def __init__(self, app, launch_uri):
+  def __init__(self, app, launch_uri, search_query):
     super().__init__(application=app)
 
     width = settings.get_int('window-width')
@@ -90,6 +91,8 @@ class Window(Adw.ApplicationWindow):
     history_stack_page = self.panel_stack.add_named(self.history_panel, 'history')
 
     self.page = PageBox(self, None)
+    if search_query != '':
+      launch_uri = wikipedia.search(search_query.lower(), 'en', 1, False)[1][0]
 
     if launch_uri != '':
       tabpage = self.tabview.append(self.page)
@@ -163,6 +166,9 @@ class Window(Adw.ApplicationWindow):
     self._panel_split_show_cb(self.panel_split, None)
     if settings.get_boolean('hide-tabs'):
       self._hide_tabs(True)
+
+    if search_query != '':
+      self.search_panel.search_entry.set_text(search_query)
 
   # Set actions for window
 


### PR DESCRIPTION
Code probably needs a bit of cleanup. I do a none async call to wikipedia search to get the first result. This is probably not ideal, however it is just 1 query so maybe it is acceptable. 
However for me this is working, allowing me to add commands like: 
```
/usr/bin/flatpak run --command=wike com.github.hugolabe.Wike -s television
```

My final use is a bash script that searches wikipedia for the selected text. Which I can invoke from gnome keyboard shortcut:
```
#!/bin/bash
query=$(xclip -o -selection primary)
if [ -n "$query" ]; then
	/usr/bin/flatpak run --command=wike com.github.hugolabe.Wike -s "$query" > /dev/null 2>&1 &
fi

```