### PR TITLE
Populate table of contents using section text instead of ID

### DIFF
--- a/data/gtk/toc-row.ui
+++ b/data/gtk/toc-row.ui
@@ -16,6 +16,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
         <property name="margin-end">3</property>
         <property name="halign">start</property>
         <property name="ellipsize">end</property>
+        <property name="use-markup">true</property>
       </object>
     </child>
 

--- a/src/toc.py
+++ b/src/toc.py
@@ -40,7 +40,7 @@ class TocPanel(Adw.Bin):
     if sections:
       self.title_label.set_label(title)
       for section in sections:
-        row = TocBoxRow(section['anchor'].replace('_', ' '), section['anchor'], section['toclevel'])
+        row = TocBoxRow(section['line'], section['anchor'], section['toclevel'])
         self.toc_list.append(row)
     else:
       self.title_label.set_label('')


### PR DESCRIPTION
Hi, this is a small change to address #232:

Use the section text ("line") values to populate the table of contents, rather than their IDs.

The section text may include style tags (e.g. `<i> ... </i>`), so markup formatting is enabled with the [`use-markup` property](https://docs.gtk.org/gtk4/property.Label.use-markup.html). It's actually parsing it as Pango, but most of the basic HTML style tags are [included in Pango](https://docs.gtk.org/Pango/pango_markup.html#convenience-tags).